### PR TITLE
feat(cache): Add auth cache mappers

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/GroupMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/GroupMetaMapper.java
@@ -88,4 +88,7 @@ public interface GroupMetaMapper {
       method = "deleteGroupMetasByLegacyTimeline")
   Integer deleteGroupMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit);
+
+  @UpdateProvider(type = GroupMetaSQLProviderFactory.class, method = "modifyGroupUpdatedAt")
+  void modifyUpdatedAt(@Param("groupId") long groupId, @Param("now") long now);
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/GroupMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/GroupMetaSQLProviderFactory.java
@@ -95,4 +95,9 @@ public class GroupMetaSQLProviderFactory {
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
     return getProvider().deleteGroupMetasByLegacyTimeline(legacyTimeline, limit);
   }
+
+  public static String modifyGroupUpdatedAt(
+      @Param("groupId") long groupId, @Param("now") long now) {
+    return getProvider().modifyGroupUpdatedAt(groupId, now);
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/OwnerMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/OwnerMetaMapper.java
@@ -23,6 +23,8 @@ import org.apache.gravitino.storage.relational.po.GroupPO;
 import org.apache.gravitino.storage.relational.po.OwnerRelPO;
 import org.apache.gravitino.storage.relational.po.UserOwnerRelPO;
 import org.apache.gravitino.storage.relational.po.UserPO;
+import org.apache.gravitino.storage.relational.po.auth.ChangedOwnerInfo;
+import org.apache.gravitino.storage.relational.po.auth.OwnerInfo;
 import org.apache.ibatis.annotations.InsertProvider;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.SelectProvider;
@@ -95,4 +97,12 @@ public interface OwnerMetaMapper {
       method = "deleteOwnerMetasByLegacyTimeline")
   Integer deleteOwnerMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit);
+
+  @SelectProvider(
+      type = OwnerMetaSQLProviderFactory.class,
+      method = "selectOwnerByMetadataObjectId")
+  OwnerInfo selectOwnerByMetadataObjectId(@Param("metadataObjectId") long metadataObjectId);
+
+  @SelectProvider(type = OwnerMetaSQLProviderFactory.class, method = "selectChangedOwners")
+  List<ChangedOwnerInfo> selectChangedOwners(@Param("updatedAtAfter") long updatedAtAfter);
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/OwnerMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/OwnerMetaSQLProviderFactory.java
@@ -104,4 +104,13 @@ public class OwnerMetaSQLProviderFactory {
     return getProvider()
         .batchSelectUserOwnerMetaByMetadataObjectIdAndType(metadataObjectIds, metadataObjectType);
   }
+
+  public static String selectOwnerByMetadataObjectId(
+      @Param("metadataObjectId") long metadataObjectId) {
+    return getProvider().selectOwnerByMetadataObjectId(metadataObjectId);
+  }
+
+  public static String selectChangedOwners(@Param("updatedAtAfter") long updatedAtAfter) {
+    return getProvider().selectChangedOwners(updatedAtAfter);
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/RoleMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/RoleMetaMapper.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.storage.relational.mapper;
 
 import java.util.List;
 import org.apache.gravitino.storage.relational.po.RolePO;
+import org.apache.gravitino.storage.relational.po.auth.RoleUpdatedAt;
 import org.apache.ibatis.annotations.DeleteProvider;
 import org.apache.ibatis.annotations.InsertProvider;
 import org.apache.ibatis.annotations.Param;
@@ -93,4 +94,10 @@ public interface RoleMetaMapper {
       method = "deleteRoleMetasByLegacyTimeline")
   Integer deleteRoleMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit);
+
+  @UpdateProvider(type = RoleMetaSQLProviderFactory.class, method = "touchRoleUpdatedAt")
+  void touchUpdatedAt(@Param("roleId") long roleId, @Param("now") long now);
+
+  @SelectProvider(type = RoleMetaSQLProviderFactory.class, method = "batchGetRoleUpdatedAt")
+  List<RoleUpdatedAt> batchGetUpdatedAt(@Param("roleIds") List<Long> roleIds);
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/RoleMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/RoleMetaSQLProviderFactory.java
@@ -19,6 +19,7 @@
 package org.apache.gravitino.storage.relational.mapper;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.gravitino.storage.relational.JDBCBackend.JDBCBackendType;
 import org.apache.gravitino.storage.relational.mapper.provider.base.RoleMetaBaseSQLProvider;
@@ -100,5 +101,13 @@ public class RoleMetaSQLProviderFactory {
   public static String deleteRoleMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
     return getProvider().deleteRoleMetasByLegacyTimeline(legacyTimeline, limit);
+  }
+
+  public static String touchRoleUpdatedAt(@Param("roleId") long roleId, @Param("now") long now) {
+    return getProvider().touchRoleUpdatedAt(roleId, now);
+  }
+
+  public static String batchGetRoleUpdatedAt(@Param("roleIds") List<Long> roleIds) {
+    return getProvider().batchGetRoleUpdatedAt(roleIds);
   }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/UserMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/UserMetaMapper.java
@@ -22,6 +22,7 @@ package org.apache.gravitino.storage.relational.mapper;
 import java.util.List;
 import org.apache.gravitino.storage.relational.po.ExtendedUserPO;
 import org.apache.gravitino.storage.relational.po.UserPO;
+import org.apache.gravitino.storage.relational.po.auth.UserAuthInfo;
 import org.apache.ibatis.annotations.DeleteProvider;
 import org.apache.ibatis.annotations.InsertProvider;
 import org.apache.ibatis.annotations.Param;
@@ -88,4 +89,11 @@ public interface UserMetaMapper {
       method = "deleteUserMetasByLegacyTimeline")
   Integer deleteUserMetasByLegacyTimeline(
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit);
+
+  @UpdateProvider(type = UserMetaSQLProviderFactory.class, method = "touchUserUpdatedAt")
+  void touchUpdatedAt(@Param("userId") long userId, @Param("now") long now);
+
+  @SelectProvider(type = UserMetaSQLProviderFactory.class, method = "getUserInfo")
+  UserAuthInfo getUserInfo(
+      @Param("metalakeName") String metalakeName, @Param("userName") String userName);
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/UserMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/UserMetaSQLProviderFactory.java
@@ -97,4 +97,13 @@ public class UserMetaSQLProviderFactory {
       @Param("legacyTimeline") Long legacyTimeline, @Param("limit") int limit) {
     return getProvider().deleteUserMetasByLegacyTimeline(legacyTimeline, limit);
   }
+
+  public static String touchUserUpdatedAt(@Param("userId") long userId, @Param("now") long now) {
+    return getProvider().touchUserUpdatedAt(userId, now);
+  }
+
+  public static String getUserInfo(
+      @Param("metalakeName") String metalakeName, @Param("userName") String userName) {
+    return getProvider().getUserInfo(metalakeName, userName);
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/GroupMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/GroupMetaBaseSQLProvider.java
@@ -182,4 +182,8 @@ public class GroupMetaBaseSQLProvider {
         + GROUP_TABLE_NAME
         + " WHERE deleted_at > 0 AND deleted_at < #{legacyTimeline} LIMIT #{limit}";
   }
+
+  public String modifyGroupUpdatedAt(@Param("groupId") long groupId, @Param("now") long now) {
+    return "UPDATE " + GROUP_TABLE_NAME + " SET updated_at = #{now} WHERE group_id = #{groupId}";
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/OwnerMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/OwnerMetaBaseSQLProvider.java
@@ -109,7 +109,7 @@ public class OwnerMetaBaseSQLProvider {
     return "INSERT INTO "
         + OWNER_TABLE_NAME
         + " (metalake_id, metadata_object_id, metadata_object_type, owner_id, owner_type,"
-        + " audit_info, current_version, last_version, deleted_at)"
+        + " audit_info, current_version, last_version, deleted_at, updated_at)"
         + " VALUES ("
         + " #{ownerRelPO.metalakeId},"
         + " #{ownerRelPO.metadataObjectId},"
@@ -119,7 +119,8 @@ public class OwnerMetaBaseSQLProvider {
         + " #{ownerRelPO.auditInfo},"
         + " #{ownerRelPO.currentVersion},"
         + " #{ownerRelPO.lastVersion},"
-        + " #{ownerRelPO.deletedAt}"
+        + " #{ownerRelPO.deletedAt},"
+        + " #{ownerRelPO.updatedAt}"
         + ")";
   }
 
@@ -246,5 +247,20 @@ public class OwnerMetaBaseSQLProvider {
     return "DELETE FROM "
         + OWNER_TABLE_NAME
         + " WHERE deleted_at > 0 AND deleted_at < #{legacyTimeline} LIMIT #{limit}";
+  }
+
+  public String selectOwnerByMetadataObjectId(@Param("metadataObjectId") long metadataObjectId) {
+    return "SELECT owner_id as ownerId, owner_type as ownerType FROM "
+        + OWNER_TABLE_NAME
+        + " WHERE metadata_object_id = #{metadataObjectId} AND deleted_at = 0"
+        + " ORDER BY updated_at DESC, id DESC LIMIT 1";
+  }
+
+  public String selectChangedOwners(@Param("updatedAtAfter") long updatedAtAfter) {
+    return "SELECT metadata_object_id as metadataObjectId, updated_at as updatedAt"
+        + " FROM "
+        + OWNER_TABLE_NAME
+        + " WHERE deleted_at = 0 AND updated_at >= #{updatedAtAfter}"
+        + " ORDER BY updated_at, id LIMIT 1000";
   }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/RoleMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/RoleMetaBaseSQLProvider.java
@@ -22,6 +22,7 @@ import static org.apache.gravitino.storage.relational.mapper.RoleMetaMapper.GROU
 import static org.apache.gravitino.storage.relational.mapper.RoleMetaMapper.ROLE_TABLE_NAME;
 import static org.apache.gravitino.storage.relational.mapper.RoleMetaMapper.USER_ROLE_RELATION_TABLE_NAME;
 
+import java.util.List;
 import org.apache.gravitino.storage.relational.mapper.MetalakeMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.SecurableObjectMapper;
 import org.apache.gravitino.storage.relational.po.RolePO;
@@ -191,5 +192,16 @@ public class RoleMetaBaseSQLProvider {
     return "DELETE FROM "
         + ROLE_TABLE_NAME
         + " WHERE deleted_at > 0 AND deleted_at < #{legacyTimeline} LIMIT #{limit}";
+  }
+
+  public String touchRoleUpdatedAt(@Param("roleId") long roleId, @Param("now") long now) {
+    return "UPDATE " + ROLE_TABLE_NAME + " SET updated_at = #{now} WHERE role_id = #{roleId}";
+  }
+
+  public String batchGetRoleUpdatedAt(@Param("roleIds") List<Long> roleIds) {
+    return "<script>SELECT role_id as roleId, role_name as roleName, updated_at as updatedAt FROM "
+        + ROLE_TABLE_NAME
+        + " WHERE role_id IN <foreach item='id' collection='roleIds' open='(' separator=',' close=')'>#{id}</foreach>"
+        + " AND deleted_at = 0</script>";
   }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/UserMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/UserMetaBaseSQLProvider.java
@@ -187,4 +187,21 @@ public class UserMetaBaseSQLProvider {
         + USER_TABLE_NAME
         + " WHERE deleted_at > 0 AND deleted_at < #{legacyTimeline} LIMIT #{limit}";
   }
+
+  public String touchUserUpdatedAt(@Param("userId") long userId, @Param("now") long now) {
+    return "UPDATE " + USER_TABLE_NAME + " SET updated_at = #{now} WHERE user_id = #{userId}";
+  }
+
+  public String getUserInfo(
+      @Param("metalakeName") String metalakeName, @Param("userName") String userName) {
+    return "SELECT um.user_id as userId, um.updated_at as updatedAt"
+        + " FROM "
+        + USER_TABLE_NAME
+        + " um"
+        + " JOIN "
+        + MetalakeMetaMapper.TABLE_NAME
+        + " mm ON um.metalake_id = mm.metalake_id AND mm.deleted_at = 0"
+        + " WHERE mm.metalake_name = #{metalakeName} AND um.user_name = #{userName}"
+        + " AND um.deleted_at = 0";
+  }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/OwnerRelPO.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/OwnerRelPO.java
@@ -35,6 +35,7 @@ public class OwnerRelPO {
   private Long currentVersion;
   private Long lastVersion;
   private Long deletedAt;
+  private Long updatedAt;
 
   private OwnerRelPO() {}
 
@@ -94,6 +95,11 @@ public class OwnerRelPO {
       return this;
     }
 
+    public Builder withUpdatedAt(Long updatedAt) {
+      ownerRelPO.updatedAt = updatedAt;
+      return this;
+    }
+
     public OwnerRelPO build() {
       validate();
       return ownerRelPO;
@@ -111,6 +117,7 @@ public class OwnerRelPO {
       Preconditions.checkArgument(ownerRelPO.currentVersion != null, "Current version is required");
       Preconditions.checkArgument(ownerRelPO.lastVersion != null, "Last version is required");
       Preconditions.checkArgument(ownerRelPO.deletedAt != null, "Deleted at is required");
+      Preconditions.checkArgument(ownerRelPO.updatedAt != null, "Updated at is required");
     }
   }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/auth/ChangedOwnerInfo.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/auth/ChangedOwnerInfo.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.po.auth;
+
+/** Owner change poller result -- one row per changed owner_meta entry. */
+public class ChangedOwnerInfo {
+  private long metadataObjectId;
+  private long updatedAt;
+
+  /** Required by MyBatis for result mapping. */
+  public ChangedOwnerInfo() {}
+
+  public ChangedOwnerInfo(long metadataObjectId, long updatedAt) {
+    this.metadataObjectId = metadataObjectId;
+    this.updatedAt = updatedAt;
+  }
+
+  public long getMetadataObjectId() {
+    return metadataObjectId;
+  }
+
+  public void setMetadataObjectId(long metadataObjectId) {
+    this.metadataObjectId = metadataObjectId;
+  }
+
+  public long getUpdatedAt() {
+    return updatedAt;
+  }
+
+  public void setUpdatedAt(long updatedAt) {
+    this.updatedAt = updatedAt;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/auth/OwnerInfo.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/auth/OwnerInfo.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.po.auth;
+
+/** Step 2.5: owner identity for a single metadata object. */
+public class OwnerInfo {
+  private long ownerId;
+  private String ownerType;
+
+  /** Required by MyBatis for result mapping. */
+  public OwnerInfo() {}
+
+  public OwnerInfo(long ownerId, String ownerType) {
+    this.ownerId = ownerId;
+    this.ownerType = ownerType;
+  }
+
+  public long getOwnerId() {
+    return ownerId;
+  }
+
+  public void setOwnerId(long ownerId) {
+    this.ownerId = ownerId;
+  }
+
+  public String getOwnerType() {
+    return ownerType;
+  }
+
+  public void setOwnerType(String ownerType) {
+    this.ownerType = ownerType;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/auth/RoleUpdatedAt.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/auth/RoleUpdatedAt.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.po.auth;
+
+/** Step 3: role version sentinel returned by batch query. */
+public class RoleUpdatedAt {
+  private long roleId;
+  private String roleName;
+  private long updatedAt;
+
+  /** Required by MyBatis for result mapping. */
+  public RoleUpdatedAt() {}
+
+  public RoleUpdatedAt(long roleId, long updatedAt) {
+    this.roleId = roleId;
+    this.updatedAt = updatedAt;
+  }
+
+  public RoleUpdatedAt(long roleId, String roleName, long updatedAt) {
+    this.roleId = roleId;
+    this.roleName = roleName;
+    this.updatedAt = updatedAt;
+  }
+
+  public long getRoleId() {
+    return roleId;
+  }
+
+  public void setRoleId(long roleId) {
+    this.roleId = roleId;
+  }
+
+  public String getRoleName() {
+    return roleName;
+  }
+
+  public void setRoleName(String roleName) {
+    this.roleName = roleName;
+  }
+
+  public long getUpdatedAt() {
+    return updatedAt;
+  }
+
+  public void setUpdatedAt(long updatedAt) {
+    this.updatedAt = updatedAt;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/auth/UserAuthInfo.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/auth/UserAuthInfo.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.po.auth;
+
+/** Step 1a result: user identity + role-list staleness sentinel. */
+public class UserAuthInfo {
+  private long userId;
+  private long updatedAt;
+
+  /** Required by MyBatis for result mapping. */
+  public UserAuthInfo() {}
+
+  public UserAuthInfo(long userId, long updatedAt) {
+    this.userId = userId;
+    this.updatedAt = updatedAt;
+  }
+
+  public long getUserId() {
+    return userId;
+  }
+
+  public void setUserId(long userId) {
+    this.userId = userId;
+  }
+
+  public long getUpdatedAt() {
+    return updatedAt;
+  }
+
+  public void setUpdatedAt(long updatedAt) {
+    this.updatedAt = updatedAt;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/GroupMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/GroupMetaService.java
@@ -259,6 +259,12 @@ public class GroupMetaService {
                 mapper ->
                     mapper.softDeleteGroupRoleRelByGroupAndRoles(
                         newEntity.id(), Lists.newArrayList(deleteRoleIds)));
+          },
+          () -> {
+            long now = System.currentTimeMillis();
+            SessionUtils.doWithoutCommit(
+                GroupMetaMapper.class,
+                mapper -> mapper.modifyUpdatedAt(oldGroupPO.getGroupId(), now));
           });
     } catch (RuntimeException re) {
       ExceptionUtils.checkSQLException(

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/RoleMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/RoleMetaService.java
@@ -259,6 +259,11 @@ public class RoleMetaService {
             SessionUtils.doWithoutCommit(
                 SecurableObjectMapper.class,
                 mapper -> mapper.batchInsertSecurableObjects(insertSecurableObjectPOs));
+          },
+          () -> {
+            long now = System.currentTimeMillis();
+            SessionUtils.doWithoutCommit(
+                RoleMetaMapper.class, mapper -> mapper.touchUpdatedAt(rolePO.getRoleId(), now));
           });
 
       return newRoleEntity;

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/UserMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/UserMetaService.java
@@ -252,6 +252,11 @@ public class UserMetaService {
                 mapper ->
                     mapper.softDeleteUserRoleRelByUserAndRoles(
                         newEntity.id(), Lists.newArrayList(deleteRoleIds)));
+          },
+          () -> {
+            long now = System.currentTimeMillis();
+            SessionUtils.doWithoutCommit(
+                UserMetaMapper.class, mapper -> mapper.touchUpdatedAt(oldUserPO.getUserId(), now));
           });
     } catch (RuntimeException re) {
       ExceptionUtils.checkSQLException(

--- a/core/src/main/java/org/apache/gravitino/storage/relational/utils/POConverters.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/utils/POConverters.java
@@ -1575,6 +1575,7 @@ public class POConverters {
           .withCurrentVersion(INIT_VERSION)
           .withLastVersion(INIT_VERSION)
           .withDeleteAt(DEFAULT_DELETED_AT)
+          .withUpdatedAt(System.currentTimeMillis())
           .build();
     } catch (JsonProcessingException e) {
       throw new RuntimeException("Failed to serialize json object:", e);

--- a/core/src/test/java/org/apache/gravitino/storage/relational/mapper/provider/base/TestAuthMappers.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/mapper/provider/base/TestAuthMappers.java
@@ -1,0 +1,380 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.storage.relational.mapper.provider.base;
+
+import com.google.common.collect.Lists;
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.apache.commons.io.FileUtils;
+import org.apache.gravitino.Config;
+import org.apache.gravitino.Configs;
+import org.apache.gravitino.meta.AuditInfo;
+import org.apache.gravitino.storage.relational.JDBCBackend;
+import org.apache.gravitino.storage.relational.mapper.GroupMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.MetalakeMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.OwnerMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.RoleMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.UserMetaMapper;
+import org.apache.gravitino.storage.relational.po.GroupPO;
+import org.apache.gravitino.storage.relational.po.MetalakePO;
+import org.apache.gravitino.storage.relational.po.OwnerRelPO;
+import org.apache.gravitino.storage.relational.po.RolePO;
+import org.apache.gravitino.storage.relational.po.UserPO;
+import org.apache.gravitino.storage.relational.po.auth.ChangedOwnerInfo;
+import org.apache.gravitino.storage.relational.po.auth.OwnerInfo;
+import org.apache.gravitino.storage.relational.po.auth.RoleUpdatedAt;
+import org.apache.gravitino.storage.relational.po.auth.UserAuthInfo;
+import org.apache.gravitino.storage.relational.session.SqlSessionFactoryHelper;
+import org.apache.ibatis.session.SqlSession;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class TestAuthMappers {
+
+  private static final String JDBC_STORE_PATH =
+      "/tmp/gravitino_jdbc_authMappers_" + UUID.randomUUID().toString().replace("-", "");
+  private static final String DB_DIR = JDBC_STORE_PATH + "/testdb";
+  private static JDBCBackend backend;
+  private static RoleMetaMapper roleMetaMapper;
+  private static UserMetaMapper userMetaMapper;
+  private static GroupMetaMapper groupMetaMapper;
+  private static OwnerMetaMapper ownerMetaMapper;
+  private static MetalakeMetaMapper metalakeMetaMapper;
+  private static SqlSession sharedSession;
+
+  @BeforeAll
+  public static void setup() throws Exception {
+    File dir = new File(DB_DIR);
+    if (dir.exists()) {
+      FileUtils.deleteDirectory(dir);
+    }
+    dir.mkdirs();
+
+    Config config = Mockito.mock(Config.class);
+    Mockito.when(config.get(Configs.ENTITY_STORE)).thenReturn("relational");
+    Mockito.when(config.get(Configs.ENTITY_RELATIONAL_STORE)).thenReturn("h2");
+    Mockito.when(config.get(Configs.ENTITY_RELATIONAL_JDBC_BACKEND_URL))
+        .thenReturn(String.format("jdbc:h2:file:%s;DB_CLOSE_DELAY=-1;MODE=MYSQL", DB_DIR));
+    Mockito.when(config.get(Configs.ENTITY_RELATIONAL_JDBC_BACKEND_USER)).thenReturn("gravitino");
+    Mockito.when(config.get(Configs.ENTITY_RELATIONAL_JDBC_BACKEND_PASSWORD))
+        .thenReturn("gravitino");
+    Mockito.when(config.get(Configs.ENTITY_RELATIONAL_JDBC_BACKEND_DRIVER))
+        .thenReturn("org.h2.Driver");
+    Mockito.when(config.get(Configs.ENTITY_RELATIONAL_JDBC_BACKEND_MAX_CONNECTIONS)).thenReturn(20);
+    Mockito.when(config.get(Configs.ENTITY_RELATIONAL_JDBC_BACKEND_WAIT_MILLISECONDS))
+        .thenReturn(1000L);
+
+    backend = new JDBCBackend();
+    backend.initialize(config);
+
+    sharedSession = SqlSessionFactoryHelper.getInstance().getSqlSessionFactory().openSession(true);
+    roleMetaMapper = sharedSession.getMapper(RoleMetaMapper.class);
+    userMetaMapper = sharedSession.getMapper(UserMetaMapper.class);
+    groupMetaMapper = sharedSession.getMapper(GroupMetaMapper.class);
+    ownerMetaMapper = sharedSession.getMapper(OwnerMetaMapper.class);
+    metalakeMetaMapper = sharedSession.getMapper(MetalakeMetaMapper.class);
+  }
+
+  @AfterAll
+  public static void tearDown() throws IOException {
+    if (sharedSession != null) {
+      sharedSession.close();
+    }
+    if (backend != null) {
+      backend.close();
+    }
+    File dir = new File(JDBC_STORE_PATH);
+    if (dir.exists()) {
+      FileUtils.deleteDirectory(dir);
+    }
+  }
+
+  @BeforeEach
+  public void truncateTables() {
+    try (SqlSession sqlSession =
+        SqlSessionFactoryHelper.getInstance().getSqlSessionFactory().openSession(true)) {
+      try (Connection connection = sqlSession.getConnection()) {
+        try (Statement statement = connection.createStatement()) {
+          statement.execute("TRUNCATE TABLE entity_change_log");
+          statement.execute("TRUNCATE TABLE owner_meta");
+          statement.execute("TRUNCATE TABLE user_role_rel");
+          statement.execute("TRUNCATE TABLE group_role_rel");
+          statement.execute("TRUNCATE TABLE role_meta_securable_object");
+          statement.execute("TRUNCATE TABLE user_meta");
+          statement.execute("TRUNCATE TABLE group_meta");
+          statement.execute("TRUNCATE TABLE role_meta");
+          statement.execute("TRUNCATE TABLE metalake_meta");
+        }
+      }
+    } catch (SQLException e) {
+      throw new RuntimeException("Truncate table failed", e);
+    }
+  }
+
+  private AuditInfo buildAuditInfo() {
+    return AuditInfo.builder().withCreator("test").withCreateTime(Instant.now()).build();
+  }
+
+  private MetalakePO insertMetalake(long metalakeId, String metalakeName) {
+    AuditInfo auditInfo = buildAuditInfo();
+    MetalakePO metalakePO =
+        MetalakePO.builder()
+            .withMetalakeId(metalakeId)
+            .withMetalakeName(metalakeName)
+            .withAuditInfo(auditInfo.toString())
+            .withSchemaVersion("1.0")
+            .withCurrentVersion(1L)
+            .withLastVersion(0L)
+            .withDeletedAt(0L)
+            .build();
+    metalakeMetaMapper.insertMetalakeMeta(metalakePO);
+    return metalakePO;
+  }
+
+  private UserPO insertUser(long userId, String userName, long metalakeId) {
+    AuditInfo auditInfo = buildAuditInfo();
+    UserPO userPO =
+        UserPO.builder()
+            .withUserId(userId)
+            .withUserName(userName)
+            .withMetalakeId(metalakeId)
+            .withAuditInfo(auditInfo.toString())
+            .withCurrentVersion(1L)
+            .withLastVersion(0L)
+            .withDeletedAt(0L)
+            .build();
+    userMetaMapper.insertUserMeta(userPO);
+    return userPO;
+  }
+
+  private RolePO insertRole(long roleId, String roleName, long metalakeId) {
+    AuditInfo auditInfo = buildAuditInfo();
+    RolePO rolePO =
+        RolePO.builder()
+            .withRoleId(roleId)
+            .withRoleName(roleName)
+            .withMetalakeId(metalakeId)
+            .withAuditInfo(auditInfo.toString())
+            .withCurrentVersion(1L)
+            .withLastVersion(0L)
+            .withDeletedAt(0L)
+            .build();
+    roleMetaMapper.insertRoleMeta(rolePO);
+    return rolePO;
+  }
+
+  private GroupPO insertGroup(long groupId, String groupName, long metalakeId) {
+    AuditInfo auditInfo = buildAuditInfo();
+    GroupPO groupPO =
+        GroupPO.builder()
+            .withGroupId(groupId)
+            .withGroupName(groupName)
+            .withMetalakeId(metalakeId)
+            .withAuditInfo(auditInfo.toString())
+            .withCurrentVersion(1L)
+            .withLastVersion(0L)
+            .withDeletedAt(0L)
+            .build();
+    groupMetaMapper.insertGroupMeta(groupPO);
+    return groupPO;
+  }
+
+  private long queryUpdatedAt(String table, String idColumn, long idValue) {
+    try (SqlSession sqlSession =
+        SqlSessionFactoryHelper.getInstance().getSqlSessionFactory().openSession(true)) {
+      try (Connection connection = sqlSession.getConnection()) {
+        String query = "SELECT updated_at FROM " + table + " WHERE " + idColumn + " = ?";
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+          statement.setLong(1, idValue);
+          try (ResultSet rs = statement.executeQuery()) {
+            if (rs.next()) {
+              return rs.getLong(1);
+            }
+            return -1;
+          }
+        }
+      }
+    } catch (SQLException e) {
+      throw new RuntimeException("SQL execution failed", e);
+    }
+  }
+
+  @Test
+  void testRoleMetaTouchUpdatedAt() {
+    insertMetalake(1L, "metalake1");
+    insertRole(10L, "role10", 1L);
+
+    long before = queryUpdatedAt("role_meta", "role_id", 10L);
+    Assertions.assertEquals(0L, before);
+
+    long now = System.currentTimeMillis();
+    roleMetaMapper.touchUpdatedAt(10L, now);
+
+    long after = queryUpdatedAt("role_meta", "role_id", 10L);
+    Assertions.assertEquals(now, after);
+  }
+
+  @Test
+  void testRoleMetaBatchGetUpdatedAt() {
+    insertMetalake(1L, "metalake1");
+    insertRole(11L, "role11", 1L);
+    insertRole(12L, "role12", 1L);
+
+    roleMetaMapper.touchUpdatedAt(11L, 1000L);
+    roleMetaMapper.touchUpdatedAt(12L, 2000L);
+
+    List<Long> roleIds = Lists.newArrayList(11L, 12L);
+    List<RoleUpdatedAt> results = roleMetaMapper.batchGetUpdatedAt(roleIds);
+
+    Assertions.assertEquals(2, results.size());
+    results.sort((a, b) -> Long.compare(a.getRoleId(), b.getRoleId()));
+    Assertions.assertEquals(11L, results.get(0).getRoleId());
+    Assertions.assertEquals(1000L, results.get(0).getUpdatedAt());
+    Assertions.assertEquals(12L, results.get(1).getRoleId());
+    Assertions.assertEquals(2000L, results.get(1).getUpdatedAt());
+  }
+
+  @Test
+  void testUserMetaTouchUpdatedAt() {
+    insertMetalake(1L, "metalake1");
+    insertUser(20L, "user20", 1L);
+
+    long before = queryUpdatedAt("user_meta", "user_id", 20L);
+    Assertions.assertEquals(0L, before);
+
+    long now = System.currentTimeMillis();
+    userMetaMapper.touchUpdatedAt(20L, now);
+
+    long after = queryUpdatedAt("user_meta", "user_id", 20L);
+    Assertions.assertEquals(now, after);
+  }
+
+  @Test
+  void testUserMetaGetUserInfo() {
+    insertMetalake(1L, "metalake1");
+    insertUser(21L, "user21", 1L);
+
+    long now = System.currentTimeMillis();
+    userMetaMapper.touchUpdatedAt(21L, now);
+
+    UserAuthInfo info = userMetaMapper.getUserInfo("metalake1", "user21");
+    Assertions.assertNotNull(info);
+    Assertions.assertEquals(21L, info.getUserId());
+    Assertions.assertEquals(now, info.getUpdatedAt());
+  }
+
+  @Test
+  void testGroupMetaTouchUpdatedAt() {
+    insertMetalake(1L, "metalake1");
+    insertGroup(30L, "group30", 1L);
+
+    long before = queryUpdatedAt("group_meta", "group_id", 30L);
+    Assertions.assertEquals(0L, before);
+
+    long now = System.currentTimeMillis();
+    groupMetaMapper.modifyUpdatedAt(30L, now);
+
+    long after = queryUpdatedAt("group_meta", "group_id", 30L);
+    Assertions.assertEquals(now, after);
+  }
+
+  @Test
+  void testOwnerMetaSelectOwnerByMetadataObjectId() {
+    insertMetalake(1L, "metalake1");
+    insertUser(50L, "user50", 1L);
+    AuditInfo auditInfo = buildAuditInfo();
+
+    OwnerRelPO ownerRelPO =
+        OwnerRelPO.builder()
+            .withMetalakeId(1L)
+            .withOwnerId(50L)
+            .withOwnerType("USER")
+            .withMetadataObjectId(100L)
+            .withMetadataObjectType("TABLE")
+            .withAuditIfo(auditInfo.toString())
+            .withCurrentVersion(1L)
+            .withLastVersion(0L)
+            .withDeleteAt(0L)
+            .withUpdatedAt(0L)
+            .build();
+    ownerMetaMapper.insertOwnerRel(ownerRelPO);
+
+    OwnerInfo info = ownerMetaMapper.selectOwnerByMetadataObjectId(100L);
+    Assertions.assertNotNull(info);
+    Assertions.assertEquals(50L, info.getOwnerId());
+    Assertions.assertEquals("USER", info.getOwnerType());
+  }
+
+  @Test
+  void testOwnerMetaSelectChangedOwners() {
+    insertMetalake(1L, "metalake1");
+    insertUser(60L, "user60", 1L);
+    AuditInfo auditInfo = buildAuditInfo();
+
+    OwnerRelPO ownerRelPO =
+        OwnerRelPO.builder()
+            .withMetalakeId(1L)
+            .withOwnerId(60L)
+            .withOwnerType("USER")
+            .withMetadataObjectId(200L)
+            .withMetadataObjectType("SCHEMA")
+            .withAuditIfo(auditInfo.toString())
+            .withCurrentVersion(1L)
+            .withLastVersion(0L)
+            .withDeleteAt(0L)
+            .withUpdatedAt(0L)
+            .build();
+    ownerMetaMapper.insertOwnerRel(ownerRelPO);
+
+    // Set updated_at = 100 via direct SQL
+    try (SqlSession sqlSession =
+        SqlSessionFactoryHelper.getInstance().getSqlSessionFactory().openSession(true)) {
+      try (Connection connection = sqlSession.getConnection()) {
+        try (Statement statement = connection.createStatement()) {
+          statement.execute(
+              "UPDATE owner_meta SET updated_at = 100 WHERE metadata_object_id = 200");
+        }
+      }
+    } catch (SQLException e) {
+      throw new RuntimeException("Update failed", e);
+    }
+
+    List<ChangedOwnerInfo> changed = ownerMetaMapper.selectChangedOwners(50L);
+    Assertions.assertEquals(1, changed.size());
+    Assertions.assertEquals(200L, changed.get(0).getMetadataObjectId());
+    Assertions.assertEquals(100L, changed.get(0).getUpdatedAt());
+
+    // With the same timestamp, the row is returned again for timestamp-only polling.
+    List<ChangedOwnerInfo> sameTimestamp = ownerMetaMapper.selectChangedOwners(100L);
+    Assertions.assertEquals(1, sameTimestamp.size());
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add auth-related mapper methods, provider SQL, auth PO classes, write-path updated_at touches, and focused mapper tests.

### Why are the changes needed?

This is the auth mapper foundation for cache improvement. It depends on the 1.3.0 schema PR and is independent from the entity change log PR.

Fix: #

### Does this PR introduce _any_ user-facing change?

No user-facing API change. This adds internal relational mapper support for auth cache consistency.

### How was this patch tested?

./gradlew :core:test --tests org.apache.gravitino.storage.relational.mapper.provider.base.TestAuthMappers