### PR TITLE
feat(cache): Add entity change log mapper

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/EntityChangeLogMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/EntityChangeLogMapper.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper;
+
+import java.util.List;
+import org.apache.gravitino.storage.relational.po.auth.EntityChangeRecord;
+import org.apache.gravitino.storage.relational.po.auth.OperateType;
+import org.apache.ibatis.annotations.DeleteProvider;
+import org.apache.ibatis.annotations.InsertProvider;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.SelectProvider;
+
+/**
+ * A MyBatis Mapper for entity_change_log table operations.
+ *
+ * <p>This append-only log tracks structural changes to entities (create, alter, drop) and is used
+ * by the entity change poller to drive targeted invalidation of the metadataIdCache on HA peer
+ * nodes.
+ */
+public interface EntityChangeLogMapper {
+
+  String ENTITY_CHANGE_LOG_TABLE_NAME = "entity_change_log";
+
+  @SelectProvider(type = EntityChangeLogSQLProviderFactory.class, method = "selectEntityChanges")
+  List<EntityChangeRecord> selectChanges(
+      @Param("createdAtAfter") long createdAtAfter, @Param("maxRows") int maxRows);
+
+  @InsertProvider(type = EntityChangeLogSQLProviderFactory.class, method = "insertEntityChange")
+  void insertChange(
+      @Param("metalakeName") String metalakeName,
+      @Param("entityType") String entityType,
+      @Param("fullName") String fullName,
+      @Param("operateType") OperateType operateType,
+      @Param("createdAt") long createdAt);
+
+  @DeleteProvider(type = EntityChangeLogSQLProviderFactory.class, method = "pruneOldEntityChanges")
+  void pruneOldEntries(@Param("before") long before);
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/EntityChangeLogSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/EntityChangeLogSQLProviderFactory.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper;
+
+import static org.apache.gravitino.storage.relational.mapper.EntityChangeLogMapper.ENTITY_CHANGE_LOG_TABLE_NAME;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.apache.gravitino.storage.relational.JDBCBackend.JDBCBackendType;
+import org.apache.gravitino.storage.relational.mapper.provider.base.EntityChangeLogBaseSQLProvider;
+import org.apache.gravitino.storage.relational.po.auth.OperateType;
+import org.apache.gravitino.storage.relational.session.SqlSessionFactoryHelper;
+import org.apache.ibatis.annotations.Param;
+
+public class EntityChangeLogSQLProviderFactory {
+
+  private static final Map<JDBCBackendType, EntityChangeLogBaseSQLProvider>
+      ENTITY_CHANGE_LOG_SQL_PROVIDER_MAP =
+          ImmutableMap.of(
+              JDBCBackendType.MYSQL, new EntityChangeLogMySQLProvider(),
+              JDBCBackendType.H2, new EntityChangeLogH2Provider(),
+              JDBCBackendType.POSTGRESQL, new EntityChangeLogPostgreSQLProvider());
+
+  public static EntityChangeLogBaseSQLProvider getProvider() {
+    String databaseId =
+        SqlSessionFactoryHelper.getInstance()
+            .getSqlSessionFactory()
+            .getConfiguration()
+            .getDatabaseId();
+    JDBCBackendType jdbcBackendType = JDBCBackendType.fromString(databaseId);
+    return ENTITY_CHANGE_LOG_SQL_PROVIDER_MAP.get(jdbcBackendType);
+  }
+
+  static class EntityChangeLogMySQLProvider extends EntityChangeLogBaseSQLProvider {}
+
+  static class EntityChangeLogH2Provider extends EntityChangeLogBaseSQLProvider {}
+
+  static class EntityChangeLogPostgreSQLProvider extends EntityChangeLogBaseSQLProvider {
+    @Override
+    public String pruneOldEntityChanges(@Param("before") long before) {
+      return "DELETE FROM "
+          + ENTITY_CHANGE_LOG_TABLE_NAME
+          + " WHERE id IN (SELECT id FROM "
+          + ENTITY_CHANGE_LOG_TABLE_NAME
+          + " WHERE created_at < #{before} ORDER BY created_at LIMIT 1000)";
+    }
+  }
+
+  public static String selectEntityChanges(
+      @Param("createdAtAfter") long createdAtAfter, @Param("maxRows") int maxRows) {
+    return getProvider().selectEntityChanges(createdAtAfter, maxRows);
+  }
+
+  public static String insertEntityChange(
+      @Param("metalakeName") String metalakeName,
+      @Param("entityType") String entityType,
+      @Param("fullName") String fullName,
+      @Param("operateType") OperateType operateType,
+      @Param("createdAt") long createdAt) {
+    return getProvider()
+        .insertEntityChange(metalakeName, entityType, fullName, operateType, createdAt);
+  }
+
+  public static String pruneOldEntityChanges(@Param("before") long before) {
+    return getProvider().pruneOldEntityChanges(before);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/OperateTypeTypeHandler.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/OperateTypeTypeHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.apache.gravitino.storage.relational.po.auth.OperateType;
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.MappedTypes;
+
+/**
+ * MyBatis type handler that maps {@link OperateType} to its stable numeric code stored in the
+ * {@code entity_change_log.operate_type} column.
+ */
+@MappedTypes(OperateType.class)
+public class OperateTypeTypeHandler extends BaseTypeHandler<OperateType> {
+
+  @Override
+  public void setNonNullParameter(
+      PreparedStatement ps, int i, OperateType parameter, JdbcType jdbcType) throws SQLException {
+    ps.setInt(i, parameter.getCode());
+  }
+
+  @Override
+  public OperateType getNullableResult(ResultSet rs, String columnName) throws SQLException {
+    int code = rs.getInt(columnName);
+    return rs.wasNull() ? null : OperateType.fromCode(code);
+  }
+
+  @Override
+  public OperateType getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+    int code = rs.getInt(columnIndex);
+    return rs.wasNull() ? null : OperateType.fromCode(code);
+  }
+
+  @Override
+  public OperateType getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+    int code = cs.getInt(columnIndex);
+    return cs.wasNull() ? null : OperateType.fromCode(code);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/DefaultMapperPackageProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/DefaultMapperPackageProvider.java
@@ -21,6 +21,7 @@ package org.apache.gravitino.storage.relational.mapper.provider;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import org.apache.gravitino.storage.relational.mapper.CatalogMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.EntityChangeLogMapper;
 import org.apache.gravitino.storage.relational.mapper.FilesetMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.FilesetVersionMapper;
 import org.apache.gravitino.storage.relational.mapper.FunctionMetaMapper;
@@ -59,6 +60,7 @@ public class DefaultMapperPackageProvider implements MapperPackageProvider {
   public List<Class<?>> getMapperClasses() {
     return ImmutableList.of(
         CatalogMetaMapper.class,
+        EntityChangeLogMapper.class,
         FilesetMetaMapper.class,
         FilesetVersionMapper.class,
         FunctionMetaMapper.class,

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/EntityChangeLogBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/EntityChangeLogBaseSQLProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.mapper.provider.base;
+
+import static org.apache.gravitino.storage.relational.mapper.EntityChangeLogMapper.ENTITY_CHANGE_LOG_TABLE_NAME;
+
+import org.apache.gravitino.storage.relational.po.auth.OperateType;
+import org.apache.ibatis.annotations.Param;
+
+public class EntityChangeLogBaseSQLProvider {
+
+  public String selectEntityChanges(
+      @Param("createdAtAfter") long createdAtAfter, @Param("maxRows") int maxRows) {
+    return "SELECT metalake_name as metalakeName, entity_type as entityType,"
+        + " full_name as fullName, operate_type as operateType, created_at as createdAt"
+        + " FROM "
+        + ENTITY_CHANGE_LOG_TABLE_NAME
+        + " WHERE created_at >= #{createdAtAfter} ORDER BY created_at LIMIT #{maxRows}";
+  }
+
+  public String insertEntityChange(
+      @Param("metalakeName") String metalakeName,
+      @Param("entityType") String entityType,
+      @Param("fullName") String fullName,
+      @Param("operateType") OperateType operateType,
+      @Param("createdAt") long createdAt) {
+    return "INSERT INTO "
+        + ENTITY_CHANGE_LOG_TABLE_NAME
+        + " (metalake_name, entity_type, full_name, operate_type, created_at)"
+        + " VALUES (#{metalakeName}, #{entityType}, #{fullName}, #{operateType}, #{createdAt})";
+  }
+
+  public String pruneOldEntityChanges(@Param("before") long before) {
+    return "DELETE FROM "
+        + ENTITY_CHANGE_LOG_TABLE_NAME
+        + " WHERE created_at < #{before} LIMIT 1000";
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/auth/EntityChangeRecord.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/auth/EntityChangeRecord.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.po.auth;
+
+/** Entity change poller result -- one row per entity_change_log entry. */
+public class EntityChangeRecord {
+  private String metalakeName;
+  private String entityType;
+  private String fullName;
+  private OperateType operateType;
+  private long createdAt;
+
+  /** Required by MyBatis for result mapping. */
+  public EntityChangeRecord() {}
+
+  public EntityChangeRecord(
+      String metalakeName,
+      String entityType,
+      String fullName,
+      OperateType operateType,
+      long createdAt) {
+    this.metalakeName = metalakeName;
+    this.entityType = entityType;
+    this.fullName = fullName;
+    this.operateType = operateType;
+    this.createdAt = createdAt;
+  }
+
+  public String getMetalakeName() {
+    return metalakeName;
+  }
+
+  public void setMetalakeName(String metalakeName) {
+    this.metalakeName = metalakeName;
+  }
+
+  public String getEntityType() {
+    return entityType;
+  }
+
+  public void setEntityType(String entityType) {
+    this.entityType = entityType;
+  }
+
+  public String getFullName() {
+    return fullName;
+  }
+
+  public void setFullName(String fullName) {
+    this.fullName = fullName;
+  }
+
+  public OperateType getOperateType() {
+    return operateType;
+  }
+
+  public void setOperateType(OperateType operateType) {
+    this.operateType = operateType;
+  }
+
+  public long getCreatedAt() {
+    return createdAt;
+  }
+
+  public void setCreatedAt(long createdAt) {
+    this.createdAt = createdAt;
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/auth/OperateType.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/auth/OperateType.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.po.auth;
+
+/**
+ * Operate type emitted into {@code entity_change_log.operate_type}.
+ *
+ * <p>The numeric {@code code} is what is persisted in the database. Codes are stable forever and
+ * must never be reused: removing a value from this enum is allowed, but the same numeric code
+ * cannot subsequently be assigned to a different meaning, otherwise old log rows would be
+ * misinterpreted by readers.
+ */
+public enum OperateType {
+  RENAME(1),
+  DROP(2),
+  INSERT(3);
+
+  private final int code;
+
+  OperateType(int code) {
+    this.code = code;
+  }
+
+  public int getCode() {
+    return code;
+  }
+
+  public static OperateType fromCode(int code) {
+    for (OperateType type : values()) {
+      if (type.code == code) {
+        return type;
+      }
+    }
+    throw new IllegalArgumentException("Unknown OperateType code: " + code);
+  }
+}

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/CatalogMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/CatalogMetaService.java
@@ -24,6 +24,7 @@ import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.gravitino.Entity;
@@ -38,6 +39,7 @@ import org.apache.gravitino.meta.SchemaEntity;
 import org.apache.gravitino.metrics.Monitored;
 import org.apache.gravitino.storage.relational.helper.CatalogIds;
 import org.apache.gravitino.storage.relational.mapper.CatalogMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.EntityChangeLogMapper;
 import org.apache.gravitino.storage.relational.mapper.FilesetMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.FilesetVersionMapper;
 import org.apache.gravitino.storage.relational.mapper.FunctionMetaMapper;
@@ -56,6 +58,7 @@ import org.apache.gravitino.storage.relational.mapper.TagMetadataObjectRelMapper
 import org.apache.gravitino.storage.relational.mapper.TopicMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.ViewMetaMapper;
 import org.apache.gravitino.storage.relational.po.CatalogPO;
+import org.apache.gravitino.storage.relational.po.auth.OperateType;
 import org.apache.gravitino.storage.relational.utils.ExceptionUtils;
 import org.apache.gravitino.storage.relational.utils.POConverters;
 import org.apache.gravitino.storage.relational.utils.SessionUtils;
@@ -219,23 +222,44 @@ public class CatalogMetaService {
         newEntity.id(),
         oldCatalogEntity.id());
 
-    Integer updateResult;
+    String metalakeName = identifier.namespace().level(0);
+    String oldFullName = oldCatalogEntity.name();
+    String newFullName = newEntity.name();
+    boolean isRenamed = !Objects.equals(oldFullName, newFullName);
+
+    AtomicInteger updateResult = new AtomicInteger(0);
     try {
-      updateResult =
-          SessionUtils.doWithCommitAndFetchResult(
-              CatalogMetaMapper.class,
-              mapper ->
-                  mapper.updateCatalogMeta(
-                      POConverters.updateCatalogPOWithVersion(
-                          oldCatalogPO, newEntity, oldCatalogPO.getMetalakeId()),
-                      oldCatalogPO));
+      SessionUtils.doMultipleWithCommit(
+          () ->
+              updateResult.set(
+                  SessionUtils.getWithoutCommit(
+                      CatalogMetaMapper.class,
+                      mapper ->
+                          mapper.updateCatalogMeta(
+                              POConverters.updateCatalogPOWithVersion(
+                                  oldCatalogPO, newEntity, oldCatalogPO.getMetalakeId()),
+                              oldCatalogPO))),
+          () -> {
+            if (isRenamed && updateResult.get() > 0) {
+              long now = System.currentTimeMillis();
+              SessionUtils.doWithoutCommit(
+                  EntityChangeLogMapper.class,
+                  mapper ->
+                      mapper.insertChange(
+                          metalakeName,
+                          Entity.EntityType.CATALOG.name(),
+                          oldFullName,
+                          OperateType.RENAME,
+                          now));
+            }
+          });
     } catch (RuntimeException re) {
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.CATALOG, newEntity.nameIdentifier().toString());
       throw re;
     }
 
-    if (updateResult > 0) {
+    if (updateResult.get() > 0) {
       return newEntity;
     } else {
       throw new IOException("Failed to update the entity: " + identifier);
@@ -250,6 +274,7 @@ public class CatalogMetaService {
 
     String catalogName = identifier.name();
     long catalogId = EntityIdService.getEntityId(identifier, Entity.EntityType.CATALOG);
+    String metalakeName = identifier.namespace().level(0);
 
     if (cascade) {
       SessionUtils.doMultipleWithCommit(
@@ -322,8 +347,19 @@ public class CatalogMetaService {
                   mapper -> mapper.softDeleteStatisticsByCatalogId(catalogId)),
           () ->
               SessionUtils.doWithoutCommit(
-                  ViewMetaMapper.class,
-                  mapper -> mapper.softDeleteViewMetasByCatalogId(catalogId)));
+                  ViewMetaMapper.class, mapper -> mapper.softDeleteViewMetasByCatalogId(catalogId)),
+          () -> {
+            long now = System.currentTimeMillis();
+            SessionUtils.doWithoutCommit(
+                EntityChangeLogMapper.class,
+                mapper ->
+                    mapper.insertChange(
+                        metalakeName,
+                        Entity.EntityType.CATALOG.name(),
+                        catalogName,
+                        OperateType.DROP,
+                        now));
+          });
     } else {
       List<SchemaEntity> schemaEntities =
           SchemaMetaService.getInstance()
@@ -365,7 +401,19 @@ public class CatalogMetaService {
                   PolicyMetadataObjectRelMapper.class,
                   mapper ->
                       mapper.softDeletePolicyMetadataObjectRelsByMetadataObject(
-                          catalogId, MetadataObject.Type.CATALOG.name())));
+                          catalogId, MetadataObject.Type.CATALOG.name())),
+          () -> {
+            long now = System.currentTimeMillis();
+            SessionUtils.doWithoutCommit(
+                EntityChangeLogMapper.class,
+                mapper ->
+                    mapper.insertChange(
+                        metalakeName,
+                        Entity.EntityType.CATALOG.name(),
+                        catalogName,
+                        OperateType.DROP,
+                        now));
+          });
     }
 
     return true;

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/FilesetMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/FilesetMetaService.java
@@ -36,6 +36,7 @@ import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.meta.FilesetEntity;
 import org.apache.gravitino.meta.NamespacedEntityId;
 import org.apache.gravitino.metrics.Monitored;
+import org.apache.gravitino.storage.relational.mapper.EntityChangeLogMapper;
 import org.apache.gravitino.storage.relational.mapper.FilesetMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.FilesetVersionMapper;
 import org.apache.gravitino.storage.relational.mapper.OwnerMetaMapper;
@@ -45,6 +46,7 @@ import org.apache.gravitino.storage.relational.mapper.StatisticMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.TagMetadataObjectRelMapper;
 import org.apache.gravitino.storage.relational.po.FilesetMaxVersionPO;
 import org.apache.gravitino.storage.relational.po.FilesetPO;
+import org.apache.gravitino.storage.relational.po.auth.OperateType;
 import org.apache.gravitino.storage.relational.utils.ExceptionUtils;
 import org.apache.gravitino.storage.relational.utils.POConverters;
 import org.apache.gravitino.storage.relational.utils.SessionUtils;
@@ -207,6 +209,12 @@ public class FilesetMetaService {
         newEntity.id(),
         oldFilesetEntity.id());
 
+    String metalakeName = identifier.namespace().level(0);
+    String catalogName = identifier.namespace().level(1);
+    String schemaName = identifier.namespace().level(2);
+    String oldFullName = catalogName + "." + schemaName + "." + oldFilesetEntity.name();
+    boolean isRenamed = !Objects.equals(oldFilesetEntity.name(), newEntity.name());
+
     Integer updateResult;
     try {
       boolean checkNeedUpdateVersion =
@@ -234,6 +242,20 @@ public class FilesetMetaService {
                 if (metaUpdateCountRef[0] == 0) {
                   throw new RuntimeException("Failed to update the entity: " + identifier);
                 }
+              },
+              () -> {
+                if (isRenamed && metaUpdateCountRef[0] > 0) {
+                  long now = System.currentTimeMillis();
+                  SessionUtils.doWithoutCommit(
+                      EntityChangeLogMapper.class,
+                      mapper ->
+                          mapper.insertChange(
+                              metalakeName,
+                              Entity.EntityType.FILESET.name(),
+                              oldFullName,
+                              OperateType.RENAME,
+                              now));
+                }
               });
           updateResult = 1;
         } catch (RuntimeException re) {
@@ -248,10 +270,28 @@ public class FilesetMetaService {
           }
         }
       } else {
-        updateResult =
-            SessionUtils.doWithCommitAndFetchResult(
-                FilesetMetaMapper.class,
-                mapper -> mapper.updateFilesetMeta(newFilesetPO, oldFilesetPO));
+        int[] metaUpdateCountRef = new int[1];
+        SessionUtils.doMultipleWithCommit(
+            () ->
+                metaUpdateCountRef[0] =
+                    SessionUtils.getWithoutCommit(
+                        FilesetMetaMapper.class,
+                        mapper -> mapper.updateFilesetMeta(newFilesetPO, oldFilesetPO)),
+            () -> {
+              if (isRenamed && metaUpdateCountRef[0] > 0) {
+                long now = System.currentTimeMillis();
+                SessionUtils.doWithoutCommit(
+                    EntityChangeLogMapper.class,
+                    mapper ->
+                        mapper.insertChange(
+                            metalakeName,
+                            Entity.EntityType.FILESET.name(),
+                            oldFullName,
+                            OperateType.RENAME,
+                            now));
+              }
+            });
+        updateResult = metaUpdateCountRef[0];
       }
     } catch (RuntimeException re) {
       ExceptionUtils.checkSQLException(
@@ -272,6 +312,11 @@ public class FilesetMetaService {
   public boolean deleteFileset(NameIdentifier identifier) {
     FilesetPO filesetPO = getFilesetPOByIdentifier(identifier);
     Long filesetId = filesetPO.getFilesetId();
+
+    String metalakeName = identifier.namespace().level(0);
+    String catalogName = identifier.namespace().level(1);
+    String schemaName = identifier.namespace().level(2);
+    String filesetFullName = catalogName + "." + schemaName + "." + identifier.name();
 
     // We should delete meta and version info
     SessionUtils.doMultipleWithCommit(
@@ -310,7 +355,19 @@ public class FilesetMetaService {
                 PolicyMetadataObjectRelMapper.class,
                 mapper ->
                     mapper.softDeletePolicyMetadataObjectRelsByMetadataObject(
-                        filesetId, MetadataObject.Type.FILESET.name())));
+                        filesetId, MetadataObject.Type.FILESET.name())),
+        () -> {
+          long now = System.currentTimeMillis();
+          SessionUtils.doWithoutCommit(
+              EntityChangeLogMapper.class,
+              mapper ->
+                  mapper.insertChange(
+                      metalakeName,
+                      Entity.EntityType.FILESET.name(),
+                      filesetFullName,
+                      OperateType.DROP,
+                      now));
+        });
 
     return true;
   }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/MetalakeMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/MetalakeMetaService.java
@@ -25,6 +25,7 @@ import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.gravitino.Entity;
@@ -36,6 +37,7 @@ import org.apache.gravitino.meta.BaseMetalake;
 import org.apache.gravitino.meta.CatalogEntity;
 import org.apache.gravitino.metrics.Monitored;
 import org.apache.gravitino.storage.relational.mapper.CatalogMetaMapper;
+import org.apache.gravitino.storage.relational.mapper.EntityChangeLogMapper;
 import org.apache.gravitino.storage.relational.mapper.FilesetMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.FilesetVersionMapper;
 import org.apache.gravitino.storage.relational.mapper.FunctionMetaMapper;
@@ -64,6 +66,7 @@ import org.apache.gravitino.storage.relational.mapper.UserMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.UserRoleRelMapper;
 import org.apache.gravitino.storage.relational.mapper.ViewMetaMapper;
 import org.apache.gravitino.storage.relational.po.MetalakePO;
+import org.apache.gravitino.storage.relational.po.auth.OperateType;
 import org.apache.gravitino.storage.relational.utils.ExceptionUtils;
 import org.apache.gravitino.storage.relational.utils.POConverters;
 import org.apache.gravitino.storage.relational.utils.SessionUtils;
@@ -173,19 +176,39 @@ public class MetalakeMetaService {
         oldMetalakeEntity.id());
     MetalakePO newMetalakePO =
         POConverters.updateMetalakePOWithVersion(oldMetalakePO, newMetalakeEntity);
-    Integer updateResult;
+
+    String oldFullName = oldMetalakeEntity.name();
+    boolean isRenamed = !Objects.equals(oldMetalakeEntity.name(), newMetalakeEntity.name());
+
+    AtomicInteger updateResult = new AtomicInteger(0);
     try {
-      updateResult =
-          SessionUtils.doWithCommitAndFetchResult(
-              MetalakeMetaMapper.class,
-              mapper -> mapper.updateMetalakeMeta(newMetalakePO, oldMetalakePO));
+      SessionUtils.doMultipleWithCommit(
+          () ->
+              updateResult.set(
+                  SessionUtils.getWithoutCommit(
+                      MetalakeMetaMapper.class,
+                      mapper -> mapper.updateMetalakeMeta(newMetalakePO, oldMetalakePO))),
+          () -> {
+            if (isRenamed && updateResult.get() > 0) {
+              long now = System.currentTimeMillis();
+              SessionUtils.doWithoutCommit(
+                  EntityChangeLogMapper.class,
+                  mapper ->
+                      mapper.insertChange(
+                          oldFullName,
+                          Entity.EntityType.METALAKE.name(),
+                          oldFullName,
+                          OperateType.RENAME,
+                          now));
+            }
+          });
     } catch (RuntimeException re) {
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.METALAKE, newMetalakeEntity.nameIdentifier().toString());
       throw re;
     }
 
-    if (updateResult > 0) {
+    if (updateResult.get() > 0) {
       return newMetalakeEntity;
     } else {
       throw new IOException("Failed to update the entity: " + ident);
@@ -312,7 +335,19 @@ public class MetalakeMetaService {
             () ->
                 SessionUtils.doWithoutCommit(
                     ViewMetaMapper.class,
-                    mapper -> mapper.softDeleteViewMetasByMetalakeId(metalakeId)));
+                    mapper -> mapper.softDeleteViewMetasByMetalakeId(metalakeId)),
+            () -> {
+              long now = System.currentTimeMillis();
+              SessionUtils.doWithoutCommit(
+                  EntityChangeLogMapper.class,
+                  mapper ->
+                      mapper.insertChange(
+                          ident.name(),
+                          Entity.EntityType.METALAKE.name(),
+                          ident.name(),
+                          OperateType.DROP,
+                          now));
+            });
       } else {
         List<CatalogEntity> catalogEntities =
             CatalogMetaService.getInstance()
@@ -373,7 +408,19 @@ public class MetalakeMetaService {
             () ->
                 SessionUtils.doWithoutCommit(
                     JobMetaMapper.class,
-                    mapper -> mapper.softDeleteJobMetasByMetalakeId(metalakeId)));
+                    mapper -> mapper.softDeleteJobMetasByMetalakeId(metalakeId)),
+            () -> {
+              long now = System.currentTimeMillis();
+              SessionUtils.doWithoutCommit(
+                  EntityChangeLogMapper.class,
+                  mapper ->
+                      mapper.insertChange(
+                          ident.name(),
+                          Entity.EntityType.METALAKE.name(),
+                          ident.name(),
+                          OperateType.DROP,
+                          now));
+            });
       }
     }
     return true;

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/ModelMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/ModelMetaService.java
@@ -39,6 +39,7 @@ import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.meta.ModelEntity;
 import org.apache.gravitino.meta.NamespacedEntityId;
 import org.apache.gravitino.metrics.Monitored;
+import org.apache.gravitino.storage.relational.mapper.EntityChangeLogMapper;
 import org.apache.gravitino.storage.relational.mapper.ModelMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.ModelVersionAliasRelMapper;
 import org.apache.gravitino.storage.relational.mapper.ModelVersionMetaMapper;
@@ -48,6 +49,7 @@ import org.apache.gravitino.storage.relational.mapper.SecurableObjectMapper;
 import org.apache.gravitino.storage.relational.mapper.StatisticMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.TagMetadataObjectRelMapper;
 import org.apache.gravitino.storage.relational.po.ModelPO;
+import org.apache.gravitino.storage.relational.po.auth.OperateType;
 import org.apache.gravitino.storage.relational.utils.ExceptionUtils;
 import org.apache.gravitino.storage.relational.utils.POConverters;
 import org.apache.gravitino.storage.relational.utils.SessionUtils;
@@ -123,6 +125,11 @@ public class ModelMetaService {
     Long schemaId = modelPO.getSchemaId();
     Long modelId = modelPO.getModelId();
 
+    String metalakeName = ident.namespace().level(0);
+    String catalogName = ident.namespace().level(1);
+    String schemaName = ident.namespace().level(2);
+    String modelFullName = catalogName + "." + schemaName + "." + ident.name();
+
     AtomicInteger modelDeletedCount = new AtomicInteger();
     SessionUtils.doMultipleWithCommit(
         // delete model versions first
@@ -174,7 +181,21 @@ public class ModelMetaService {
                 PolicyMetadataObjectRelMapper.class,
                 mapper ->
                     mapper.softDeletePolicyMetadataObjectRelsByMetadataObject(
-                        modelId, MetadataObject.Type.MODEL.name())));
+                        modelId, MetadataObject.Type.MODEL.name())),
+        () -> {
+          if (modelDeletedCount.get() > 0) {
+            long now = System.currentTimeMillis();
+            SessionUtils.doWithoutCommit(
+                EntityChangeLogMapper.class,
+                mapper ->
+                    mapper.insertChange(
+                        metalakeName,
+                        Entity.EntityType.MODEL.name(),
+                        modelFullName,
+                        OperateType.DROP,
+                        now));
+          }
+        });
 
     return modelDeletedCount.get() > 0;
   }
@@ -349,21 +370,43 @@ public class ModelMetaService {
         newEntity.id(),
         oldModelEntity.id());
 
-    Integer updateResult;
+    String metalakeName = identifier.namespace().level(0);
+    String catalogName = identifier.namespace().level(1);
+    String schemaName = identifier.namespace().level(2);
+    String oldFullName = catalogName + "." + schemaName + "." + oldModelEntity.name();
+    boolean isRenamed = !Objects.equals(oldModelEntity.name(), newEntity.name());
+
+    AtomicInteger updateResult = new AtomicInteger(0);
     try {
-      updateResult =
-          SessionUtils.doWithCommitAndFetchResult(
-              ModelMetaMapper.class,
-              mapper ->
-                  mapper.updateModelMeta(
-                      POConverters.updateModelPO(oldModelPO, newEntity), oldModelPO));
+      SessionUtils.doMultipleWithCommit(
+          () ->
+              updateResult.set(
+                  SessionUtils.getWithoutCommit(
+                      ModelMetaMapper.class,
+                      mapper ->
+                          mapper.updateModelMeta(
+                              POConverters.updateModelPO(oldModelPO, newEntity), oldModelPO))),
+          () -> {
+            if (isRenamed && updateResult.get() > 0) {
+              long now = System.currentTimeMillis();
+              SessionUtils.doWithoutCommit(
+                  EntityChangeLogMapper.class,
+                  mapper ->
+                      mapper.insertChange(
+                          metalakeName,
+                          Entity.EntityType.MODEL.name(),
+                          oldFullName,
+                          OperateType.RENAME,
+                          now));
+            }
+          });
     } catch (RuntimeException re) {
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.MODEL, newEntity.nameIdentifier().toString());
       throw re;
     }
 
-    if (updateResult > 0) {
+    if (updateResult.get() > 0) {
       return newEntity;
     } else {
       throw new IOException("Failed to update the entity: " + identifier);

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/SchemaMetaService.java
@@ -24,6 +24,7 @@ import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.gravitino.Entity;
@@ -43,6 +44,7 @@ import org.apache.gravitino.meta.TableEntity;
 import org.apache.gravitino.meta.TopicEntity;
 import org.apache.gravitino.metrics.Monitored;
 import org.apache.gravitino.storage.relational.helper.SchemaIds;
+import org.apache.gravitino.storage.relational.mapper.EntityChangeLogMapper;
 import org.apache.gravitino.storage.relational.mapper.FilesetMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.FilesetVersionMapper;
 import org.apache.gravitino.storage.relational.mapper.FunctionMetaMapper;
@@ -61,6 +63,7 @@ import org.apache.gravitino.storage.relational.mapper.TagMetadataObjectRelMapper
 import org.apache.gravitino.storage.relational.mapper.TopicMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.ViewMetaMapper;
 import org.apache.gravitino.storage.relational.po.SchemaPO;
+import org.apache.gravitino.storage.relational.po.auth.OperateType;
 import org.apache.gravitino.storage.relational.utils.ExceptionUtils;
 import org.apache.gravitino.storage.relational.utils.POConverters;
 import org.apache.gravitino.storage.relational.utils.SessionUtils;
@@ -195,21 +198,43 @@ public class SchemaMetaService {
         newEntity.id(),
         oldSchemaEntity.id());
 
-    Integer updateResult;
+    String metalakeName = identifier.namespace().level(0);
+    String catalogName = identifier.namespace().level(1);
+    String oldFullName = catalogName + "." + oldSchemaEntity.name();
+    boolean isRenamed = !Objects.equals(oldSchemaEntity.name(), newEntity.name());
+
+    AtomicInteger updateResult = new AtomicInteger(0);
     try {
-      updateResult =
-          SessionUtils.doWithCommitAndFetchResult(
-              SchemaMetaMapper.class,
-              mapper ->
-                  mapper.updateSchemaMeta(
-                      POConverters.updateSchemaPOWithVersion(oldSchemaPO, newEntity), oldSchemaPO));
+      SessionUtils.doMultipleWithCommit(
+          () ->
+              updateResult.set(
+                  SessionUtils.getWithoutCommit(
+                      SchemaMetaMapper.class,
+                      mapper ->
+                          mapper.updateSchemaMeta(
+                              POConverters.updateSchemaPOWithVersion(oldSchemaPO, newEntity),
+                              oldSchemaPO))),
+          () -> {
+            if (isRenamed && updateResult.get() > 0) {
+              long now = System.currentTimeMillis();
+              SessionUtils.doWithoutCommit(
+                  EntityChangeLogMapper.class,
+                  mapper ->
+                      mapper.insertChange(
+                          metalakeName,
+                          Entity.EntityType.SCHEMA.name(),
+                          oldFullName,
+                          OperateType.RENAME,
+                          now));
+            }
+          });
     } catch (RuntimeException re) {
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.SCHEMA, newEntity.nameIdentifier().toString());
       throw re;
     }
 
-    if (updateResult > 0) {
+    if (updateResult.get() > 0) {
       return newEntity;
     } else {
       throw new IOException("Failed to update the entity: " + identifier);
@@ -225,6 +250,9 @@ public class SchemaMetaService {
     String schemaName = identifier.name();
     SchemaPO schemaPO = getSchemaPOByIdentifier(identifier);
     Long schemaId = schemaPO.getSchemaId();
+    String metalakeName = identifier.namespace().level(0);
+    String catalogName = identifier.namespace().level(1);
+    String schemaFullName = catalogName + "." + schemaName;
 
     if (cascade) {
       SessionUtils.doMultipleWithCommit(
@@ -289,7 +317,19 @@ public class SchemaMetaService {
                   mapper -> mapper.softDeleteStatisticsBySchemaId(schemaId)),
           () ->
               SessionUtils.doWithoutCommit(
-                  ViewMetaMapper.class, mapper -> mapper.softDeleteViewMetasBySchemaId(schemaId)));
+                  ViewMetaMapper.class, mapper -> mapper.softDeleteViewMetasBySchemaId(schemaId)),
+          () -> {
+            long now = System.currentTimeMillis();
+            SessionUtils.doWithoutCommit(
+                EntityChangeLogMapper.class,
+                mapper ->
+                    mapper.insertChange(
+                        metalakeName,
+                        Entity.EntityType.SCHEMA.name(),
+                        schemaFullName,
+                        OperateType.DROP,
+                        now));
+          });
     } else {
       List<TableEntity> tableEntities =
           TableMetaService.getInstance()
@@ -369,7 +409,19 @@ public class SchemaMetaService {
                   PolicyMetadataObjectRelMapper.class,
                   mapper ->
                       mapper.softDeletePolicyMetadataObjectRelsByMetadataObject(
-                          schemaId, MetadataObject.Type.SCHEMA.name())));
+                          schemaId, MetadataObject.Type.SCHEMA.name())),
+          () -> {
+            long now = System.currentTimeMillis();
+            SessionUtils.doWithoutCommit(
+                EntityChangeLogMapper.class,
+                mapper ->
+                    mapper.insertChange(
+                        metalakeName,
+                        Entity.EntityType.SCHEMA.name(),
+                        schemaFullName,
+                        OperateType.DROP,
+                        now));
+          });
     }
     return true;
   }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/TableMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/TableMetaService.java
@@ -40,6 +40,7 @@ import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.meta.NamespacedEntityId;
 import org.apache.gravitino.meta.TableEntity;
 import org.apache.gravitino.metrics.Monitored;
+import org.apache.gravitino.storage.relational.mapper.EntityChangeLogMapper;
 import org.apache.gravitino.storage.relational.mapper.OwnerMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.PolicyMetadataObjectRelMapper;
 import org.apache.gravitino.storage.relational.mapper.SecurableObjectMapper;
@@ -49,6 +50,7 @@ import org.apache.gravitino.storage.relational.mapper.TableVersionMapper;
 import org.apache.gravitino.storage.relational.mapper.TagMetadataObjectRelMapper;
 import org.apache.gravitino.storage.relational.po.ColumnPO;
 import org.apache.gravitino.storage.relational.po.TablePO;
+import org.apache.gravitino.storage.relational.po.auth.OperateType;
 import org.apache.gravitino.storage.relational.utils.ExceptionUtils;
 import org.apache.gravitino.storage.relational.utils.POConverters;
 import org.apache.gravitino.storage.relational.utils.SessionUtils;
@@ -186,6 +188,12 @@ public class TableMetaService {
     TablePO newTablePO =
         POConverters.updateTablePOWithVersionAndSchemaId(oldTablePO, newTableEntity, newSchemaId);
 
+    String metalakeName = identifier.namespace().level(0);
+    String catalogName = identifier.namespace().level(1);
+    String schemaName = identifier.namespace().level(2);
+    String oldFullName = catalogName + "." + schemaName + "." + oldTableEntity.name();
+    boolean isRenamed = !Objects.equals(oldTableEntity.name(), newTableEntity.name());
+
     final AtomicInteger updateResult = new AtomicInteger(0);
     try {
       SessionUtils.doMultipleWithCommit(
@@ -207,6 +215,20 @@ public class TableMetaService {
               TableColumnMetaService.getInstance()
                   .updateColumnPOsFromTableDiff(oldTableEntity, newTableEntity, newTablePO);
             }
+          },
+          () -> {
+            if (isRenamed && updateResult.get() > 0) {
+              long now = System.currentTimeMillis();
+              SessionUtils.doWithoutCommit(
+                  EntityChangeLogMapper.class,
+                  mapper ->
+                      mapper.insertChange(
+                          metalakeName,
+                          Entity.EntityType.TABLE.name(),
+                          oldFullName,
+                          OperateType.RENAME,
+                          now));
+            }
           });
 
     } catch (RuntimeException re) {
@@ -225,6 +247,11 @@ public class TableMetaService {
   @Monitored(metricsSource = GRAVITINO_RELATIONAL_STORE_METRIC_NAME, baseMetricName = "deleteTable")
   public boolean deleteTable(NameIdentifier identifier) {
     TablePO tablePO = getTablePOByIdentifier(identifier);
+
+    String metalakeName = identifier.namespace().level(0);
+    String catalogName = identifier.namespace().level(1);
+    String schemaName = identifier.namespace().level(2);
+    String tableFullName = catalogName + "." + schemaName + "." + identifier.name();
 
     AtomicInteger deleteResult = new AtomicInteger(0);
     SessionUtils.doMultipleWithCommit(
@@ -266,6 +293,20 @@ public class TableMetaService {
                 mapper ->
                     mapper.softDeleteTableVersionByTableIdAndVersion(
                         tablePO.getTableId(), tablePO.getCurrentVersion()));
+          }
+        },
+        () -> {
+          if (deleteResult.get() > 0) {
+            long now = System.currentTimeMillis();
+            SessionUtils.doWithoutCommit(
+                EntityChangeLogMapper.class,
+                mapper ->
+                    mapper.insertChange(
+                        metalakeName,
+                        Entity.EntityType.TABLE.name(),
+                        tableFullName,
+                        OperateType.DROP,
+                        now));
           }
         });
 

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/TopicMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/TopicMetaService.java
@@ -24,6 +24,7 @@ import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.gravitino.Entity;
@@ -36,6 +37,7 @@ import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.meta.NamespacedEntityId;
 import org.apache.gravitino.meta.TopicEntity;
 import org.apache.gravitino.metrics.Monitored;
+import org.apache.gravitino.storage.relational.mapper.EntityChangeLogMapper;
 import org.apache.gravitino.storage.relational.mapper.OwnerMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.PolicyMetadataObjectRelMapper;
 import org.apache.gravitino.storage.relational.mapper.SecurableObjectMapper;
@@ -43,6 +45,7 @@ import org.apache.gravitino.storage.relational.mapper.StatisticMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.TagMetadataObjectRelMapper;
 import org.apache.gravitino.storage.relational.mapper.TopicMetaMapper;
 import org.apache.gravitino.storage.relational.po.TopicPO;
+import org.apache.gravitino.storage.relational.po.auth.OperateType;
 import org.apache.gravitino.storage.relational.utils.ExceptionUtils;
 import org.apache.gravitino.storage.relational.utils.POConverters;
 import org.apache.gravitino.storage.relational.utils.SessionUtils;
@@ -110,21 +113,44 @@ public class TopicMetaService {
         newEntity.id(),
         oldTopicEntity.id());
 
-    Integer updateResult;
+    String metalakeName = ident.namespace().level(0);
+    String catalogName = ident.namespace().level(1);
+    String schemaName = ident.namespace().level(2);
+    String oldFullName = catalogName + "." + schemaName + "." + oldTopicEntity.name();
+    boolean isRenamed = !Objects.equals(oldTopicEntity.name(), newEntity.name());
+
+    AtomicInteger updateResult = new AtomicInteger(0);
     try {
-      updateResult =
-          SessionUtils.doWithCommitAndFetchResult(
-              TopicMetaMapper.class,
-              mapper ->
-                  mapper.updateTopicMeta(
-                      POConverters.updateTopicPOWithVersion(oldTopicPO, newEntity), oldTopicPO));
+      SessionUtils.doMultipleWithCommit(
+          () ->
+              updateResult.set(
+                  SessionUtils.getWithoutCommit(
+                      TopicMetaMapper.class,
+                      mapper ->
+                          mapper.updateTopicMeta(
+                              POConverters.updateTopicPOWithVersion(oldTopicPO, newEntity),
+                              oldTopicPO))),
+          () -> {
+            if (isRenamed && updateResult.get() > 0) {
+              long now = System.currentTimeMillis();
+              SessionUtils.doWithoutCommit(
+                  EntityChangeLogMapper.class,
+                  mapper ->
+                      mapper.insertChange(
+                          metalakeName,
+                          Entity.EntityType.TOPIC.name(),
+                          oldFullName,
+                          OperateType.RENAME,
+                          now));
+            }
+          });
     } catch (RuntimeException re) {
       ExceptionUtils.checkSQLException(
           re, Entity.EntityType.TOPIC, newEntity.nameIdentifier().toString());
       throw re;
     }
 
-    if (updateResult > 0) {
+    if (updateResult.get() > 0) {
       return newEntity;
     } else {
       throw new IOException("Failed to update the entity: " + ident);
@@ -267,6 +293,11 @@ public class TopicMetaService {
     TopicPO topicPO = getTopicPOByIdentifier(identifier);
     Long topicId = topicPO.getTopicId();
 
+    String metalakeName = identifier.namespace().level(0);
+    String catalogName = identifier.namespace().level(1);
+    String schemaName = identifier.namespace().level(2);
+    String topicFullName = catalogName + "." + schemaName + "." + identifier.name();
+
     SessionUtils.doMultipleWithCommit(
         () ->
             SessionUtils.doWithoutCommit(
@@ -298,7 +329,19 @@ public class TopicMetaService {
                 PolicyMetadataObjectRelMapper.class,
                 mapper ->
                     mapper.softDeletePolicyMetadataObjectRelsByMetadataObject(
-                        topicId, MetadataObject.Type.TOPIC.name())));
+                        topicId, MetadataObject.Type.TOPIC.name())),
+        () -> {
+          long now = System.currentTimeMillis();
+          SessionUtils.doWithoutCommit(
+              EntityChangeLogMapper.class,
+              mapper ->
+                  mapper.insertChange(
+                      metalakeName,
+                      Entity.EntityType.TOPIC.name(),
+                      topicFullName,
+                      OperateType.DROP,
+                      now));
+        });
 
     return true;
   }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/service/ViewMetaService.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/service/ViewMetaService.java
@@ -40,12 +40,14 @@ import org.apache.gravitino.Namespace;
 import org.apache.gravitino.exceptions.NoSuchEntityException;
 import org.apache.gravitino.meta.ViewEntity;
 import org.apache.gravitino.metrics.Monitored;
+import org.apache.gravitino.storage.relational.mapper.EntityChangeLogMapper;
 import org.apache.gravitino.storage.relational.mapper.OwnerMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.SecurableObjectMapper;
 import org.apache.gravitino.storage.relational.mapper.TagMetadataObjectRelMapper;
 import org.apache.gravitino.storage.relational.mapper.ViewMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.ViewVersionInfoMapper;
 import org.apache.gravitino.storage.relational.po.ViewPO;
+import org.apache.gravitino.storage.relational.po.auth.OperateType;
 import org.apache.gravitino.storage.relational.utils.ExceptionUtils;
 import org.apache.gravitino.storage.relational.utils.SessionUtils;
 import org.apache.gravitino.utils.NameIdentifierUtil;
@@ -153,6 +155,12 @@ public class ViewMetaService {
     AtomicInteger updateResult = new AtomicInteger(0);
     try {
       ViewPO newViewPO = updateViewPO(oldViewPO, newEntity);
+      String metalakeName = ident.namespace().level(0);
+      String catalogName = ident.namespace().level(1);
+      String schemaName = ident.namespace().level(2);
+      String oldFullName = catalogName + "." + schemaName + "." + oldViewPO.getViewName();
+      boolean isRenamed = !Objects.equals(oldViewPO.getViewName(), newViewPO.getViewName());
+
       SessionUtils.doMultipleWithCommit(
           () ->
               SessionUtils.doWithoutCommit(
@@ -164,6 +172,20 @@ public class ViewMetaService {
                     ViewMetaMapper.class, mapper -> mapper.updateViewMeta(newViewPO, oldViewPO)));
             if (updateResult.get() == 0) {
               throw new RuntimeException("Failed to update the entity: " + ident);
+            }
+          },
+          () -> {
+            if (isRenamed && updateResult.get() > 0) {
+              long now = System.currentTimeMillis();
+              SessionUtils.doWithoutCommit(
+                  EntityChangeLogMapper.class,
+                  mapper ->
+                      mapper.insertChange(
+                          metalakeName,
+                          Entity.EntityType.VIEW.name(),
+                          oldFullName,
+                          OperateType.RENAME,
+                          now));
             }
           });
       return newEntity;
@@ -183,7 +205,11 @@ public class ViewMetaService {
   public boolean deleteView(NameIdentifier ident) {
     NameIdentifierUtil.checkView(ident);
     ViewPO viewPO = viewPOFetcher().apply(ident);
-    return deleteView(viewPO.getViewId());
+    String metalakeName = ident.namespace().level(0);
+    String catalogName = ident.namespace().level(1);
+    String schemaName = ident.namespace().level(2);
+    String viewFullName = catalogName + "." + schemaName + "." + viewPO.getViewName();
+    return deleteView(viewPO.getViewId(), metalakeName, viewFullName);
   }
 
   @Monitored(
@@ -203,7 +229,7 @@ public class ViewMetaService {
     return versionDeletedCount + metaDeletedCount;
   }
 
-  private boolean deleteView(Long viewId) {
+  private boolean deleteView(Long viewId, String metalakeName, String viewFullName) {
     AtomicInteger deleteResult = new AtomicInteger(0);
     SessionUtils.doMultipleWithCommit(
         () ->
@@ -230,6 +256,16 @@ public class ViewMetaService {
                 mapper ->
                     mapper.softDeleteTagMetadataObjectRelsByMetadataObject(
                         viewId, MetadataObject.Type.VIEW.name()));
+            long now = System.currentTimeMillis();
+            SessionUtils.doWithoutCommit(
+                EntityChangeLogMapper.class,
+                mapper ->
+                    mapper.insertChange(
+                        metalakeName,
+                        Entity.EntityType.VIEW.name(),
+                        viewFullName,
+                        OperateType.DROP,
+                        now));
           }
         });
     return deleteResult.get() > 0;

--- a/core/src/main/java/org/apache/gravitino/storage/relational/session/SqlSessionFactoryHelper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/session/SqlSessionFactoryHelper.java
@@ -31,7 +31,9 @@ import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.metrics.MetricsSystem;
 import org.apache.gravitino.metrics.source.RelationDatasourceMetricsSource;
 import org.apache.gravitino.storage.relational.JDBCBackend.JDBCBackendType;
+import org.apache.gravitino.storage.relational.mapper.OperateTypeTypeHandler;
 import org.apache.gravitino.storage.relational.mapper.provider.MapperPackageProvider;
+import org.apache.gravitino.storage.relational.po.auth.OperateType;
 import org.apache.gravitino.utils.JdbcUrlUtils;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.Configuration;
@@ -110,6 +112,9 @@ public class SqlSessionFactoryHelper {
       // Initialize the configuration
       Configuration configuration = new Configuration(environment);
       configuration.setDatabaseId(jdbcType.name().toLowerCase());
+      configuration
+          .getTypeHandlerRegistry()
+          .register(OperateType.class, new OperateTypeTypeHandler());
       ServiceLoader<MapperPackageProvider> loader = ServiceLoader.load(MapperPackageProvider.class);
       for (MapperPackageProvider provider : loader) {
         provider.getMapperClasses().forEach(configuration::addMapper);

--- a/core/src/test/java/org/apache/gravitino/storage/relational/mapper/provider/base/TestAuthMappers.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/mapper/provider/base/TestAuthMappers.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.gravitino.storage.relational.mapper.provider.base;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import org.apache.commons.io.FileUtils;
+import org.apache.gravitino.Config;
+import org.apache.gravitino.Configs;
+import org.apache.gravitino.storage.relational.JDBCBackend;
+import org.apache.gravitino.storage.relational.mapper.EntityChangeLogMapper;
+import org.apache.gravitino.storage.relational.po.auth.EntityChangeRecord;
+import org.apache.gravitino.storage.relational.po.auth.OperateType;
+import org.apache.gravitino.storage.relational.session.SqlSessionFactoryHelper;
+import org.apache.ibatis.session.SqlSession;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class TestAuthMappers {
+
+  private static final String JDBC_STORE_PATH =
+      "/tmp/gravitino_jdbc_authMappers_" + UUID.randomUUID().toString().replace("-", "");
+  private static final String DB_DIR = JDBC_STORE_PATH + "/testdb";
+  private static JDBCBackend backend;
+  private static EntityChangeLogMapper entityChangeLogMapper;
+  private static SqlSession sharedSession;
+
+  @BeforeAll
+  public static void setup() throws Exception {
+    File dir = new File(DB_DIR);
+    if (dir.exists()) {
+      FileUtils.deleteDirectory(dir);
+    }
+    dir.mkdirs();
+
+    Config config = Mockito.mock(Config.class);
+    Mockito.when(config.get(Configs.ENTITY_STORE)).thenReturn("relational");
+    Mockito.when(config.get(Configs.ENTITY_RELATIONAL_STORE)).thenReturn("h2");
+    Mockito.when(config.get(Configs.ENTITY_RELATIONAL_JDBC_BACKEND_URL))
+        .thenReturn(String.format("jdbc:h2:file:%s;DB_CLOSE_DELAY=-1;MODE=MYSQL", DB_DIR));
+    Mockito.when(config.get(Configs.ENTITY_RELATIONAL_JDBC_BACKEND_USER)).thenReturn("gravitino");
+    Mockito.when(config.get(Configs.ENTITY_RELATIONAL_JDBC_BACKEND_PASSWORD))
+        .thenReturn("gravitino");
+    Mockito.when(config.get(Configs.ENTITY_RELATIONAL_JDBC_BACKEND_DRIVER))
+        .thenReturn("org.h2.Driver");
+    Mockito.when(config.get(Configs.ENTITY_RELATIONAL_JDBC_BACKEND_MAX_CONNECTIONS)).thenReturn(20);
+    Mockito.when(config.get(Configs.ENTITY_RELATIONAL_JDBC_BACKEND_WAIT_MILLISECONDS))
+        .thenReturn(1000L);
+
+    backend = new JDBCBackend();
+    backend.initialize(config);
+
+    sharedSession = SqlSessionFactoryHelper.getInstance().getSqlSessionFactory().openSession(true);
+    entityChangeLogMapper = sharedSession.getMapper(EntityChangeLogMapper.class);
+  }
+
+  @AfterAll
+  public static void tearDown() throws IOException {
+    if (sharedSession != null) {
+      sharedSession.close();
+    }
+    if (backend != null) {
+      backend.close();
+    }
+    File dir = new File(JDBC_STORE_PATH);
+    if (dir.exists()) {
+      FileUtils.deleteDirectory(dir);
+    }
+  }
+
+  @Test
+  void testEntityChangeLogInsertAndSelect() {
+    long now = System.currentTimeMillis();
+    entityChangeLogMapper.insertChange(
+        "metalake1", "TABLE", "cat.schema.tbl", OperateType.RENAME, now);
+
+    List<EntityChangeRecord> records = entityChangeLogMapper.selectChanges(now - 1, 10);
+    Assertions.assertEquals(1, records.size());
+    EntityChangeRecord record = records.get(0);
+    Assertions.assertEquals("metalake1", record.getMetalakeName());
+    Assertions.assertEquals("TABLE", record.getEntityType());
+    Assertions.assertEquals("cat.schema.tbl", record.getFullName());
+    Assertions.assertEquals(OperateType.RENAME, record.getOperateType());
+    Assertions.assertEquals(now, record.getCreatedAt());
+  }
+
+  @Test
+  void testEntityChangeLogPruneOldEntries() {
+    long old = 1000L;
+    long recent = System.currentTimeMillis();
+    entityChangeLogMapper.insertChange(
+        "metalake1", "SCHEMA", "cat.schema", OperateType.INSERT, old);
+    entityChangeLogMapper.insertChange(
+        "metalake1", "TABLE", "cat.schema.tbl", OperateType.DROP, recent);
+
+    entityChangeLogMapper.pruneOldEntries(old + 1);
+
+    List<EntityChangeRecord> after = entityChangeLogMapper.selectChanges(0L, 100);
+    Assertions.assertEquals(1, after.size());
+    Assertions.assertEquals(recent, after.get(0).getCreatedAt());
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add the entity_change_log mapper, operation type handling, mapper registration, write-path changelog inserts for entity rename/drop, and focused mapper tests.

### Why are the changes needed?

This is the entity change log foundation for cache invalidation. It depends on the 1.3.0 schema PR and is independent from the auth mapper PR.

Fix: #

### Does this PR introduce _any_ user-facing change?

No user-facing API change. This adds internal relational mapper support for targeted cache invalidation.

### How was this patch tested?

./gradlew :core:test --tests org.apache.gravitino.storage.relational.mapper.provider.base.TestAuthMappers