### PR TITLE
[#10983] test(lance): add Lance compatibility matrix automation

### DIFF
--- a/.github/workflows/lance-compatibility-matrix-test.yml
+++ b/.github/workflows/lance-compatibility-matrix-test.yml
@@ -1,0 +1,96 @@
+name: Lance Compatibility Matrix Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      lance_spark_versions:
+        description: "Comma-separated lance-spark-bundle versions"
+        required: false
+        default: "0.1.0,0.1.1,0.2.0,0.4.0"
+      lance_ray_versions:
+        description: "Comma-separated lance-ray versions"
+        required: false
+        default: "0.4.2,0.3.0"
+  schedule:
+    # Run weekly on main so compatibility drift is caught outside PR validation.
+    - cron: "0 18 * * 0"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lance-spark-matrix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    env:
+      LANCE_SPARK_VERSIONS: ${{ github.event.inputs.lance_spark_versions || '0.1.0,0.1.1,0.2.0,0.4.0' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: "temurin"
+          cache: "gradle"
+
+      - name: Free up disk space
+        run: dev/ci/util_free_space.sh
+
+      - name: Run Lance Spark compatibility matrix
+        id: lanceSparkMatrixTest
+        run: |
+          ./gradlew :lance:lance-rest-server:lanceSparkMatrixTest \
+            -PlanceSparkBundleVersions="${LANCE_SPARK_VERSIONS}" \
+            -PskipDockerTests=true \
+            -PskipWeb=true
+
+      - name: Upload Lance Spark matrix reports
+        uses: actions/upload-artifact@v7
+        if: ${{ failure() && steps.lanceSparkMatrixTest.outcome == 'failure' }}
+        with:
+          name: lance-spark-matrix-reports
+          path: |
+            lance/lance-rest-server/build/reports/lance-spark-matrix
+            lance/lance-rest-server/build/test-results/lance-spark-matrix
+            build/reports
+
+  lance-ray-matrix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    env:
+      LANCE_RAY_VERSIONS: ${{ github.event.inputs.lance_ray_versions || '0.4.2,0.3.0' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: "temurin"
+          cache: "gradle"
+
+      - name: Free up disk space
+        run: dev/ci/util_free_space.sh
+
+      - name: Package Gravitino
+        run: ./gradlew compileDistribution -PskipWeb=true -x test
+
+      - name: Run Lance Ray compatibility matrix
+        id: lanceRayMatrixTest
+        run: |
+          ./gradlew :clients:client-python:lanceRayMatrixTest \
+            -PlanceRayVersions="${LANCE_RAY_VERSIONS}" \
+            -PskipDockerTests=true \
+            -PskipWeb=true
+
+      - name: Upload Lance Ray matrix reports
+        uses: actions/upload-artifact@v7
+        if: ${{ failure() && steps.lanceRayMatrixTest.outcome == 'failure' }}
+        with:
+          name: lance-ray-matrix-reports
+          path: |
+            clients/client-python/build/lance-ray-matrix
+            build/reports
+            integration-test/build/integration-test.log
+            distribution/package/logs/gravitino-server.out
+            distribution/package/logs/gravitino-server.log

--- a/clients/client-python/build.gradle.kts
+++ b/clients/client-python/build.gradle.kts
@@ -239,6 +239,57 @@ tasks {
     finalizedBy(unitCoverageReport)
   }
 
+  // Run tests/integration/test_lance_ray.py against multiple lance-ray
+  // versions. Each version is exercised inside its own venv under
+  // build/lance-ray-matrix/.venv-<version>/ (cached across runs).
+  // Override the matrix with `-PlanceRayVersions=0.4.2,0.4.1,0.4.0`.
+  // Override the bootstrap interpreter with `-PlanceRayPython=/path/to/python`.
+  register("lanceRayMatrixTest") {
+    group = "verification"
+    description =
+      "Run tests/integration/test_lance_ray.py against multiple lance-ray " +
+        "versions. Override with -PlanceRayVersions=<csv> (default: " +
+        "tracks docs/lance-rest-integration.md Compatibility Matrix)."
+
+    val versions = project.findProperty("lanceRayVersions") as? String
+    val keepGoing = project.hasProperty("lanceRayKeepGoing")
+    val pythonExecutable =
+      (project.findProperty("lanceRayPython") as? String)?.takeIf { it.isNotBlank() } ?: "python3"
+    val script = projectDir.resolve("scripts/run_lance_ray_matrix.py")
+    val gravitinoHome = file("${project.rootDir}/distribution/package")
+
+    doFirst {
+      gravitinoServer("start")
+    }
+    doLast {
+      try {
+        val args = mutableListOf(
+          pythonExecutable,
+          script.absolutePath,
+          "--python",
+          pythonExecutable,
+          "--gravitino-home",
+          gravitinoHome.absolutePath,
+        )
+        if (!versions.isNullOrBlank()) {
+          args += listOf("--versions", versions)
+        }
+        if (keepGoing) {
+          args += "--keep-going"
+        }
+        val proc = ProcessBuilder(args)
+          .inheritIO()
+          .start()
+        val exit = proc.waitFor()
+        if (exit != 0) {
+          throw GradleException("lance-ray matrix failed with exit code $exit")
+        }
+      } finally {
+        gravitinoServer("stop")
+      }
+    }
+  }
+
   register("test", VenvTask::class) {
     val skipUTs = project.hasProperty("skipTests")
     val skipITs = project.hasProperty("skipITs")

--- a/clients/client-python/requirements-dev.txt
+++ b/clients/client-python/requirements-dev.txt
@@ -34,8 +34,10 @@ sphinx==7.1.2
 furo==2024.8.6
 banks==2.4.1
 
-# Lance integration deps. Pinned so integration tests run against a single,
-# known-good server-side `lance-namespace-core` 0.7.5+ combination.
+# Lance integration deps. Pinned so the default integration test runs against
+# a single, known-good (server-side `lance-namespace-core` 0.7.5+) combination.
+# The multi-version matrix (`:clients:client-python:lanceRayMatrixTest`) keeps
+# its own per-version venvs and does not consume these pins.
 ray==2.55.1
 lance-ray==0.4.2
 lance-namespace==0.7.5

--- a/clients/client-python/scripts/run_lance_ray_matrix.py
+++ b/clients/client-python/scripts/run_lance_ray_matrix.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Run ``tests/integration/test_lance_ray.py`` against multiple lance-ray
+versions to validate the supported range advertised in the Compatibility
+Matrix (``docs/lance-rest-integration.md``).
+
+For each version we provision a dedicated venv under
+``clients/client-python/build/lance-ray-matrix/.venv-<version>/`` and install
+``ray``, ``lance-ray==<version>``, ``lance-namespace``, ``requests``, plus the
+in-tree ``apache-gravitino`` distribution (editable). The unittest itself is
+launched per-version with ``python -m unittest -v
+tests.integration.test_lance_ray``; results are collected into a pass/fail
+table at the end.
+
+The caller is responsible for starting the Gravitino server (with the
+auxiliary lance-rest service enabled). The Gradle wrapper task
+``:clients:client-python:lanceRayMatrixTest`` handles that. For ad-hoc local
+use::
+
+    distribution/package/bin/gravitino.sh start
+    python3 clients/client-python/scripts/run_lance_ray_matrix.py \
+        --versions 0.4.2,0.4.1 \
+        --gravitino-home distribution/package
+    distribution/package/bin/gravitino.sh stop
+
+Each test class will append its own metalake binding to ``gravitino.conf`` and
+restart the server itself. The matrix runner opts into keeping that binding
+between versions, so back-to-back runs avoid unnecessary Gravitino restarts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+# Default version set tracks what the Compatibility Matrix in
+# docs/lance-rest-integration.md claims to support. Keep these in sync.
+DEFAULT_VERSIONS = ["0.4.2", "0.4.1", "0.4.0", "0.3.0"]
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PYTHON_CLIENT_DIR = REPO_ROOT / "clients" / "client-python"
+DEFAULT_MATRIX_DIR = PYTHON_CLIENT_DIR / "build" / "lance-ray-matrix"
+DEFAULT_GRAVITINO_HOME = REPO_ROOT / "distribution" / "package"
+
+
+@dataclass
+class VersionResult:
+    version: str
+    status: str  # "ok", "fail", "setup-error"
+    details: str
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--versions",
+        default=",".join(DEFAULT_VERSIONS),
+        help="Comma-separated list of lance-ray versions to test. "
+        f"Default: {','.join(DEFAULT_VERSIONS)}",
+    )
+    p.add_argument(
+        "--python",
+        default=sys.executable,
+        help="Path to the host python interpreter used to bootstrap each "
+        "version's venv. Default: %(default)s",
+    )
+    p.add_argument(
+        "--matrix-dir",
+        default=str(DEFAULT_MATRIX_DIR),
+        help="Directory under which per-version venvs are created and "
+        "cached across runs. Default: %(default)s",
+    )
+    p.add_argument(
+        "--gravitino-home",
+        default=str(DEFAULT_GRAVITINO_HOME),
+        help="Path to the built Gravitino distribution package. The "
+        "lance-rest aux service must be enabled there. Default: %(default)s",
+    )
+    p.add_argument(
+        "--ray-spec",
+        default="ray==2.55.1",
+        help="Pip spec for ray. Pinned by default so the matrix is "
+        "reproducible across runs and does not drift with PyPI. Override "
+        "(e.g. 'ray') to let pip pick a compatible version per lance-ray. "
+        "Default: %(default)s",
+    )
+    p.add_argument(
+        "--lance-namespace-spec",
+        default="lance-namespace==0.7.5",
+        help="Pip spec for lance-namespace. Pinned by default so the "
+        "matrix is reproducible and does not drift with PyPI. Override "
+        "(e.g. 'lance-namespace') for latest. Default: %(default)s",
+    )
+    p.add_argument(
+        "--keep-going",
+        action="store_true",
+        help="Continue to the next version after a failure instead of "
+        "stopping on the first failed run.",
+    )
+    return p.parse_args()
+
+
+def run(cmd: List[str], **kwargs) -> subprocess.CompletedProcess:
+    print(f"[matrix] $ {' '.join(cmd)}")
+    return subprocess.run(cmd, check=False, **kwargs)
+
+
+def ensure_venv(python: str, venv_dir: Path) -> Path:
+    """Create the venv if it doesn't already exist. Returns the venv python path."""
+    venv_python = venv_dir / "bin" / "python"
+    if not venv_python.exists():
+        venv_dir.parent.mkdir(parents=True, exist_ok=True)
+        rc = run([python, "-m", "venv", str(venv_dir)]).returncode
+        if rc != 0:
+            raise RuntimeError(f"Failed to create venv at {venv_dir}")
+    return venv_python
+
+
+def install_deps(
+    venv_python: Path,
+    version: str,
+    ray_spec: str,
+    lance_namespace_spec: str,
+) -> None:
+    rc = run(
+        [
+            str(venv_python),
+            "-m",
+            "pip",
+            "install",
+            "--upgrade",
+            "pip",
+            "wheel",
+        ]
+    ).returncode
+    if rc != 0:
+        raise RuntimeError("pip upgrade failed in venv")
+
+    rc = run(
+        [
+            str(venv_python),
+            "-m",
+            "pip",
+            "install",
+            ray_spec,
+            f"lance-ray=={version}",
+            lance_namespace_spec,
+            "requests",
+        ]
+    ).returncode
+    if rc != 0:
+        raise RuntimeError(f"Failed to install lance-ray=={version} deps")
+
+    rc = run(
+        [
+            str(venv_python),
+            "-m",
+            "pip",
+            "install",
+            "-e",
+            str(PYTHON_CLIENT_DIR),
+        ]
+    ).returncode
+    if rc != 0:
+        raise RuntimeError("Failed to install apache-gravitino in editable mode")
+
+
+def generate_version_ini(venv_python: Path) -> None:
+    # The python client reads gravitino/version.ini at runtime. It is
+    # produced by scripts/generate_version.py and is gitignored, so we
+    # regenerate it here to make the matrix runnable on fresh checkouts.
+    script = PYTHON_CLIENT_DIR / "scripts" / "generate_version.py"
+    rc = run(
+        [str(venv_python), str(script)],
+        cwd=str(PYTHON_CLIENT_DIR),
+    ).returncode
+    if rc != 0:
+        raise RuntimeError("Failed to generate version.ini for python client")
+
+
+def run_unittest(venv_python: Path, gravitino_home: Path) -> int:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(PYTHON_CLIENT_DIR)
+    env["GRAVITINO_HOME"] = str(gravitino_home)
+    env["START_EXTERNAL_GRAVITINO"] = "true"
+    env["LANCE_RAY_KEEP_GRAVITINO_CONF"] = "true"
+    cmd = [
+        str(venv_python),
+        "-m",
+        "unittest",
+        "-v",
+        "tests.integration.test_lance_ray",
+    ]
+    print(f"[matrix] $ PYTHONPATH=... GRAVITINO_HOME=... {' '.join(cmd)}")
+    return subprocess.run(
+        cmd, cwd=str(PYTHON_CLIENT_DIR), env=env, check=False
+    ).returncode
+
+
+def main() -> int:
+    args = parse_args()
+    versions = [v.strip() for v in args.versions.split(",") if v.strip()]
+    if not versions:
+        print("--versions must contain at least one entry", file=sys.stderr)
+        return 2
+
+    matrix_dir = Path(args.matrix_dir).resolve()
+    gravitino_home = Path(args.gravitino_home).resolve()
+    if not (gravitino_home / "bin" / "gravitino.sh").exists():
+        print(
+            f"GRAVITINO_HOME={gravitino_home} does not look like a "
+            "Gravitino distribution package (missing bin/gravitino.sh). "
+            "Run `./gradlew compileDistribution -PskipWeb=true -x test` first.",
+            file=sys.stderr,
+        )
+        return 2
+
+    results: List[VersionResult] = []
+    for version in versions:
+        print(f"\n========== lance-ray=={version} ==========")
+        venv_dir = matrix_dir / f".venv-{version}"
+        try:
+            venv_python = ensure_venv(args.python, venv_dir)
+            install_deps(
+                venv_python,
+                version,
+                args.ray_spec,
+                args.lance_namespace_spec,
+            )
+            generate_version_ini(venv_python)
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            print(f"[matrix] {version}: setup failed: {e}", file=sys.stderr)
+            results.append(VersionResult(version, "setup-error", str(e)))
+            if not args.keep_going:
+                break
+            continue
+
+        rc = run_unittest(venv_python, gravitino_home)
+        if rc == 0:
+            print(f"[matrix] {version}: PASS")
+            results.append(VersionResult(version, "ok", "tests passed"))
+        else:
+            print(f"[matrix] {version}: FAIL (exit={rc})")
+            results.append(VersionResult(version, "fail", f"unittest exit {rc}"))
+            if not args.keep_going:
+                break
+
+    print("\n========== summary ==========")
+    width = max(len(r.version) for r in results) if results else 0
+    for r in results:
+        print(f"  lance-ray=={r.version.ljust(width)}  {r.status:11s}  {r.details}")
+
+    any_fail = any(r.status != "ok" for r in results)
+    return 1 if any_fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/clients/client-python/tests/integration/test_lance_ray.py
+++ b/clients/client-python/tests/integration/test_lance_ray.py
@@ -44,6 +44,7 @@ LANCE_REST_BASE_URL = f"http://localhost:{LANCE_REST_PORT}/lance"
 # standalone lance-rest conf file.
 MAIN_CONF_FILE = "conf/gravitino.conf"
 LANCE_REST_METALAKE_KEY = "gravitino.lance-rest.gravitino-metalake"
+KEEP_GRAVITINO_CONF_ENV = "LANCE_RAY_KEEP_GRAVITINO_CONF"
 
 
 def _missing_lance_ray_deps() -> Optional[str]:
@@ -67,9 +68,11 @@ class TestLanceRayIntegration(IntegrationTestEnv):
     ``read_lance`` flow from the upstream lance-ray docs.
     """
 
-    # Metalake name is fixed because the lance-rest aux service binds to a
-    # single metalake from gravitino.conf. The per-test table name still gets
-    # a random suffix to keep individual test methods isolated.
+    # Metalake name is fixed (not randomized) so back-to-back runs in the
+    # same Gravitino process can detect that the lance-rest aux service is
+    # already bound and skip the costly server restart. The per-test table
+    # name still gets a random suffix to keep individual test methods
+    # isolated.
     METALAKE_NAME: str = "lance_ray_test_metalake"
     CATALOG_NAME: str = "lance_catalog"
     SCHEMA_NAME: str = "schema"
@@ -95,8 +98,8 @@ class TestLanceRayIntegration(IntegrationTestEnv):
         # Bind the lance-rest aux service to our test metalake. If the same
         # binding is already present (e.g. an earlier run in the same Gradle
         # session left it there), skip the conf write and the restart. This
-        # avoids appending the same conf entry twice if a prior failed run
-        # already left the binding behind.
+        # avoids restarting Gravitino in the middle of the IT suite when the
+        # test class is replayed, which would briefly disrupt other ITs.
         if not cls._lance_metalake_already_bound():
             cls._append_conf(cls._lance_rest_config(), cls.main_conf_path)
             cls.appended_lance_rest_conf = True
@@ -115,7 +118,7 @@ class TestLanceRayIntegration(IntegrationTestEnv):
         # so a skipped run leaves no fixtures behind.
         skip_reason = cls._check_lance_namespace_compat()
         if skip_reason is not None:
-            cls._reset_lance_rest_conf()
+            cls._reset_lance_rest_conf_if_needed()
             raise unittest.SkipTest(skip_reason)
 
         cls.gravitino_admin_client = GravitinoAdminClient("http://localhost:8090")
@@ -176,7 +179,7 @@ class TestLanceRayIntegration(IntegrationTestEnv):
             failures.append(("drop metalake", e))
 
         try:
-            cls._reset_lance_rest_conf()
+            cls._reset_lance_rest_conf_if_needed()
         except Exception as e:  # pylint: disable=broad-exception-caught
             failures.append(("reset lance-rest conf", e))
 
@@ -259,8 +262,18 @@ class TestLanceRayIntegration(IntegrationTestEnv):
         return {LANCE_REST_METALAKE_KEY: cls.METALAKE_NAME}
 
     @classmethod
-    def _reset_lance_rest_conf(cls) -> None:
+    def _should_keep_lance_rest_conf(cls) -> bool:
+        return os.environ.get(KEEP_GRAVITINO_CONF_ENV, "").lower() == "true"
+
+    @classmethod
+    def _reset_lance_rest_conf_if_needed(cls) -> None:
         if not cls.appended_lance_rest_conf or cls.main_conf_path is None:
+            return
+        if cls._should_keep_lance_rest_conf():
+            logger.info(
+                "Keeping lance-rest Gravitino conf because %s=true",
+                KEEP_GRAVITINO_CONF_ENV,
+            )
             return
         cls._reset_conf(cls._lance_rest_config(), cls.main_conf_path)
         cls.appended_lance_rest_conf = False

--- a/docs/lance-rest-integration.md
+++ b/docs/lance-rest-integration.md
@@ -37,6 +37,27 @@ The following table outlines the tested compatibility between Gravitino versions
 - The Lance ecosystem is changing quickly, so some versions may introduce breaking changes.
 :::
 
+#### Reproducing the matrix locally
+
+Both connectors ship with a multi-version integration test driver so the
+matrix can be re-verified (and extended) without ad-hoc scripting:
+
+```bash
+# lance-spark — runs LanceSparkRESTServiceIT once per bundle version
+./gradlew :lance:lance-rest-server:lanceSparkMatrixTest \
+    -PlanceSparkBundleVersions=0.1.0,0.1.1,0.2.0,0.4.0 \
+    -PskipDockerTests=true
+# Per-version JUnit reports land under
+# lance/lance-rest-server/build/reports/lance-spark-matrix/<version>/.
+
+# lance-ray — provisions a venv per version under
+# clients/client-python/build/lance-ray-matrix/.venv-<version>/ and runs
+# tests/integration/test_lance_ray.py against each. The Gradle wrapper
+# below starts / stops Gravitino automatically.
+./gradlew :clients:client-python:lanceRayMatrixTest \
+    -PlanceRayVersions=0.4.2,0.3.0
+```
+
 ### Why Maintain a Compatibility Matrix?
 
 The Lance ecosystem is under active development, with frequent updates to APIs and features. Gravitino's Lance REST service depends on specific connector behaviors to ensure reliable operation. Using incompatible versions may result in:
@@ -163,8 +184,7 @@ pip install lance-ray
 
 :::info
 - Ray will be automatically installed if not already present
-- For Gravitino 1.3.0, use a `lance-namespace` client compatible with
-  server-side `lance-namespace-core` 0.7.5 or newer.
+- The lance-namespace version must be less than or equal to 0.4.5.
 - Ensure Ray version compatibility in your environment before deployment
 :::
 

--- a/lance/lance-rest-server/build.gradle.kts
+++ b/lance/lance-rest-server/build.gradle.kts
@@ -28,13 +28,34 @@ val scalaVersion: String =
   project.properties["scalaVersion"] as? String ?: extra["defaultScalaVersion"].toString()
 val sparkVersion: String = libs.versions.spark35.get()
 val scalaCollectionCompatVersion: String = libs.versions.scala.collection.compat.get()
-val lanceSparkBundleVersion = "0.4.0"
+// Comma-separated list of lance-spark-bundle versions to test against.
+// The default is the latest supported version; the integration test matrix
+// (`:lance:lance-rest-server:lanceSparkMatrixTest`) covers every version in
+// this list. Override via `-PlanceSparkBundleVersions=0.2.0,0.3.0,0.4.0`.
+val lanceSparkBundleVersions: List<String> =
+  ((project.properties["lanceSparkBundleVersions"] as? String) ?: "0.4.0")
+    .split(",").map { it.trim() }.filter { it.isNotEmpty() }
+if (lanceSparkBundleVersions.isEmpty()) {
+  throw GradleException("lanceSparkBundleVersions must contain at least one version")
+}
+val primaryLanceSparkBundleVersion: String = lanceSparkBundleVersions.first()
 val lanceSparkBundleJarPathProperty = "gravitino.lance.spark.bundle.jar"
-val lanceSparkBundleDir = layout.buildDirectory.dir("lance-spark-bundle")
-val lanceSparkBundle by configurations.creating {
-  isCanBeConsumed = false
-  isCanBeResolved = true
-  isTransitive = false
+
+fun lanceSparkBundleConfigName(version: String): String =
+  "lanceSparkBundle_" + version.replace(".", "_").replace("-", "_")
+fun lanceSparkBundleDirFor(version: String) =
+  layout.buildDirectory.dir("lance-spark-bundle/$version")
+fun lanceSparkPrepareTaskName(version: String): String =
+  "prepareLanceSparkBundle_" + version.replace(".", "_").replace("-", "_")
+fun lanceSparkTestTaskName(version: String): String =
+  "testLanceSparkBundle_" + version.replace(".", "_").replace("-", "_")
+
+lanceSparkBundleVersions.forEach { version ->
+  configurations.create(lanceSparkBundleConfigName(version)) {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+    isTransitive = false
+  }
 }
 
 dependencies {
@@ -80,10 +101,12 @@ dependencies {
   testImplementation(project(":integration-test-common", "testArtifacts"))
   testImplementation(libs.lance)
 
-  add(
-    lanceSparkBundle.name,
-    "org.lance:lance-spark-bundle-3.5_2.12:$lanceSparkBundleVersion"
-  )
+  lanceSparkBundleVersions.forEach { version ->
+    add(
+      lanceSparkBundleConfigName(version),
+      "org.lance:lance-spark-bundle-3.5_2.12:$version"
+    )
+  }
 
   testImplementation("org.scala-lang.modules:scala-collection-compat_$scalaVersion:$scalaCollectionCompatVersion")
   testImplementation("org.apache.spark:spark-sql_$scalaVersion:$sparkVersion") {
@@ -119,10 +142,17 @@ tasks {
     from(configurations.runtimeClasspath)
     into("build/libs")
   }
-  val prepareLanceSparkBundle by registering(Sync::class) {
-    from(lanceSparkBundle)
-    into(lanceSparkBundleDir)
+  // One Sync task per lance-spark-bundle version. Each task lays down its
+  // bundle jar under build/lance-spark-bundle/<version>/ so per-version Test
+  // tasks pick up the right jar without colliding.
+  lanceSparkBundleVersions.forEach { version ->
+    register<Sync>(lanceSparkPrepareTaskName(version)) {
+      from(configurations.getByName(lanceSparkBundleConfigName(version)))
+      into(lanceSparkBundleDirFor(version))
+    }
   }
+  val primaryPrepareLanceSparkBundle =
+    named(lanceSparkPrepareTaskName(primaryLanceSparkBundleVersion))
 
   jar {
     finalizedBy(copyDepends)
@@ -153,13 +183,14 @@ tasks {
   }
 
   test {
-    dependsOn(prepareLanceSparkBundle)
+    dependsOn(primaryPrepareLanceSparkBundle)
 
+    val primaryBundleDir = lanceSparkBundleDirFor(primaryLanceSparkBundleVersion)
     doFirst {
       val bundleJar =
-        lanceSparkBundleDir.get().asFile.listFiles()?.singleOrNull { it.extension == "jar" }
+        primaryBundleDir.get().asFile.listFiles()?.singleOrNull { it.extension == "jar" }
           ?: throw GradleException(
-            "Expected exactly one Lance Spark bundle jar in ${lanceSparkBundleDir.get().asFile}"
+            "Expected exactly one Lance Spark bundle jar in ${primaryBundleDir.get().asFile}"
           )
       systemProperty(lanceSparkBundleJarPathProperty, bundleJar.absolutePath)
     }
@@ -168,6 +199,64 @@ tasks {
     if (testMode == "embedded") {
       dependsOn(":catalogs:catalog-lakehouse-generic:jar")
     }
+  }
+
+  // Per-version Test task that only runs LanceSparkRESTServiceIT against a
+  // specific lance-spark-bundle. Each task downloads its bundle through the
+  // matching Sync task and points the IT JVM at it via system property.
+  lanceSparkBundleVersions.forEach { version ->
+    register<Test>(lanceSparkTestTaskName(version)) {
+      group = "verification"
+      description =
+        "Run LanceSparkRESTServiceIT against lance-spark-bundle $version"
+
+      dependsOn(named(lanceSparkPrepareTaskName(version)))
+      dependsOn(named("jar"))
+      val versionTestMode = project.properties["testMode"] as? String ?: "embedded"
+      if (versionTestMode == "embedded") {
+        dependsOn(":catalogs:catalog-lakehouse-generic:jar")
+      }
+
+      testClassesDirs = sourceSets["test"].output.classesDirs
+      classpath = sourceSets["test"].runtimeClasspath
+      useJUnitPlatform()
+      filter { includeTestsMatching("*LanceSparkRESTServiceIT*") }
+
+      val versionBundleDir = lanceSparkBundleDirFor(version)
+      doFirst {
+        val bundleJar =
+          versionBundleDir.get().asFile.listFiles()?.singleOrNull { it.extension == "jar" }
+            ?: throw GradleException(
+              "Expected exactly one Lance Spark bundle jar in " +
+                "${versionBundleDir.get().asFile} for version $version"
+            )
+        systemProperty(lanceSparkBundleJarPathProperty, bundleJar.absolutePath)
+        println("[lance-spark-matrix] running IT against bundle $version -> ${bundleJar.name}")
+      }
+
+      // Send per-version reports to a separate directory so a matrix run
+      // doesn't overwrite results across versions.
+      val versionSlug = version.replace(".", "_").replace("-", "_")
+      reports {
+        html.outputLocation.set(
+          layout.buildDirectory.dir("reports/lance-spark-matrix/$versionSlug")
+        )
+        junitXml.outputLocation.set(
+          layout.buildDirectory.dir("test-results/lance-spark-matrix/$versionSlug")
+        )
+      }
+    }
+  }
+
+  register("lanceSparkMatrixTest") {
+    group = "verification"
+    description =
+      "Run LanceSparkRESTServiceIT against every version in -PlanceSparkBundleVersions " +
+      "(default: $primaryLanceSparkBundleVersion). Reports land under " +
+      "build/reports/lance-spark-matrix/<version>/."
+    dependsOn(
+      lanceSparkBundleVersions.map { named(lanceSparkTestTaskName(it)) }
+    )
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is stacked on #11060 and should be merged after #11060.

It adds a separate Lance compatibility matrix validation path:
- Add `:lance:lance-rest-server:lanceSparkMatrixTest` to run `LanceSparkRESTServiceIT` against multiple `lance-spark-bundle` versions.
- Add `:clients:client-python:lanceRayMatrixTest` and `scripts/run_lance_ray_matrix.py` to run the Lance Ray integration test against multiple `lance-ray` versions with isolated per-version virtualenvs.
- Add a standalone `Lance Compatibility Matrix Test` GitHub Actions workflow, triggered by `workflow_dispatch` and weekly schedule only.
- Document how to reproduce the Lance Spark and Lance Ray matrix locally.

### Why are the changes needed?

The default PR validation should keep using a single pinned, known-good Lance dependency combination so normal PR checks stay stable and reasonably fast.

The full compatibility matrix is still useful for catching Lance ecosystem compatibility drift, but it should run as a separate automation path instead of being part of every PR validation.

Fix: #10983

### Does this PR introduce _any_ user-facing change?

No user-facing API change.

This adds developer/CI validation tooling and documentation for Lance compatibility testing.

### How was this patch tested?

- `./gradlew :lance:lance-rest-server:spotlessApply :clients:client-python:pylint -PskipITs`
- `./gradlew :lance:lance-rest-server:test -PskipITs`
- `git diff --cached --check`

The full multi-version matrix was not run locally because it downloads and runs multiple external Lance dependency combinations.
