### PR TITLE
[#11088] feat(authz): Route isSelf(ROLE) through cache + batch user/group version probes

### DIFF
--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/UserMetaMapper.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/UserMetaMapper.java
@@ -22,6 +22,7 @@ package org.apache.gravitino.storage.relational.mapper;
 import java.util.List;
 import org.apache.gravitino.storage.relational.po.ExtendedUserPO;
 import org.apache.gravitino.storage.relational.po.UserPO;
+import org.apache.gravitino.storage.relational.po.auth.AuthSubjectVersion;
 import org.apache.gravitino.storage.relational.po.auth.UserUpdatedAt;
 import org.apache.ibatis.annotations.DeleteProvider;
 import org.apache.ibatis.annotations.InsertProvider;
@@ -96,4 +97,23 @@ public interface UserMetaMapper {
   @SelectProvider(type = UserMetaSQLProviderFactory.class, method = "getUserUpdatedAt")
   UserUpdatedAt getUserUpdatedAt(
       @Param("metalakeName") String metalakeName, @Param("userName") String userName);
+
+  /**
+   * One-shot UNION probe that returns {@code (id, name, updated_at)} for one user and (optionally)
+   * any number of groups in the same metalake. Used by the authorization hot path to collapse the
+   * per-user + per-group version probes into a single round trip.
+   *
+   * <p>When {@code groupNames} is empty the GROUP side of the UNION is omitted entirely (the SQL
+   * provider returns a user-only SELECT) so callers do not need to special-case that branch.
+   *
+   * @param metalakeName the metalake the user and groups belong to
+   * @param userName the user to probe
+   * @param groupNames the group names to probe; may be empty (never null)
+   * @return one row per matching user/group; missing entities are simply absent
+   */
+  @SelectProvider(type = UserMetaSQLProviderFactory.class, method = "batchGetUserAndGroupUpdatedAt")
+  List<AuthSubjectVersion> batchGetUserAndGroupUpdatedAt(
+      @Param("metalakeName") String metalakeName,
+      @Param("userName") String userName,
+      @Param("groupNames") List<String> groupNames);
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/UserMetaSQLProviderFactory.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/UserMetaSQLProviderFactory.java
@@ -20,6 +20,7 @@
 package org.apache.gravitino.storage.relational.mapper;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.gravitino.storage.relational.JDBCBackend.JDBCBackendType;
 import org.apache.gravitino.storage.relational.mapper.provider.base.UserMetaBaseSQLProvider;
@@ -105,5 +106,12 @@ public class UserMetaSQLProviderFactory {
   public static String getUserUpdatedAt(
       @Param("metalakeName") String metalakeName, @Param("userName") String userName) {
     return getProvider().getUserUpdatedAt(metalakeName, userName);
+  }
+
+  public static String batchGetUserAndGroupUpdatedAt(
+      @Param("metalakeName") String metalakeName,
+      @Param("userName") String userName,
+      @Param("groupNames") List<String> groupNames) {
+    return getProvider().batchGetUserAndGroupUpdatedAt(metalakeName, userName, groupNames);
   }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/UserMetaBaseSQLProvider.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/mapper/provider/base/UserMetaBaseSQLProvider.java
@@ -19,10 +19,12 @@
 
 package org.apache.gravitino.storage.relational.mapper.provider.base;
 
+import static org.apache.gravitino.storage.relational.mapper.GroupMetaMapper.GROUP_TABLE_NAME;
 import static org.apache.gravitino.storage.relational.mapper.RoleMetaMapper.ROLE_TABLE_NAME;
 import static org.apache.gravitino.storage.relational.mapper.UserMetaMapper.USER_ROLE_RELATION_TABLE_NAME;
 import static org.apache.gravitino.storage.relational.mapper.UserRoleRelMapper.USER_TABLE_NAME;
 
+import java.util.List;
 import org.apache.gravitino.storage.relational.mapper.MetalakeMetaMapper;
 import org.apache.gravitino.storage.relational.po.UserPO;
 import org.apache.ibatis.annotations.Param;
@@ -207,5 +209,45 @@ public class UserMetaBaseSQLProvider {
         + " mm ON um.metalake_id = mm.metalake_id AND mm.deleted_at = 0"
         + " WHERE mm.metalake_name = #{metalakeName} AND um.user_name = #{userName}"
         + " AND um.deleted_at = 0";
+  }
+
+  public String batchGetUserAndGroupUpdatedAt(
+      @Param("metalakeName") String metalakeName,
+      @Param("userName") String userName,
+      @Param("groupNames") List<String> groupNames) {
+    String userSelect =
+        "SELECT 'USER' as subjectType, um.user_id as id, um.user_name as name,"
+            + " um.updated_at as updatedAt"
+            + " FROM "
+            + USER_TABLE_NAME
+            + " um"
+            + " JOIN "
+            + MetalakeMetaMapper.TABLE_NAME
+            + " mm ON um.metalake_id = mm.metalake_id AND mm.deleted_at = 0"
+            + " WHERE mm.metalake_name = #{metalakeName} AND um.user_name = #{userName}"
+            + " AND um.deleted_at = 0";
+
+    if (groupNames == null || groupNames.isEmpty()) {
+      // Omit the GROUP branch entirely so the SQL stays portable across H2/MySQL/PostgreSQL
+      // and we avoid emitting an empty IN clause.
+      return userSelect;
+    }
+
+    return "<script>"
+        + userSelect
+        + " UNION ALL "
+        + "SELECT 'GROUP' as subjectType, gm.group_id as id, gm.group_name as name,"
+        + " gm.updated_at as updatedAt"
+        + " FROM "
+        + GROUP_TABLE_NAME
+        + " gm"
+        + " JOIN "
+        + MetalakeMetaMapper.TABLE_NAME
+        + " mm2 ON gm.metalake_id = mm2.metalake_id AND mm2.deleted_at = 0"
+        + " WHERE mm2.metalake_name = #{metalakeName}"
+        + " AND gm.group_name IN"
+        + " <foreach item='g' collection='groupNames' open='(' separator=',' close=')'>#{g}</foreach>"
+        + " AND gm.deleted_at = 0"
+        + "</script>";
   }
 }

--- a/core/src/main/java/org/apache/gravitino/storage/relational/po/auth/AuthSubjectVersion.java
+++ b/core/src/main/java/org/apache/gravitino/storage/relational/po/auth/AuthSubjectVersion.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.gravitino.storage.relational.po.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * One row of the batched user + group version probe. The {@code subjectType} literal column
+ * (carrying {@code "USER"} or {@code "GROUP"}) lets the caller split a single UNION result back
+ * into the per-subject {@code UserUpdatedAt} / {@code GroupUpdatedAt} snapshots used by the cache
+ * layer.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthSubjectVersion {
+
+  /** {@code "USER"} or {@code "GROUP"}. */
+  private String subjectType;
+
+  /** {@code user_id} or {@code group_id}. */
+  private long id;
+
+  /** {@code user_name} or {@code group_name}; used to match the row back to the requested key. */
+  private String name;
+
+  /** {@code updated_at} value used as the cache staleness sentinel. */
+  private long updatedAt;
+}

--- a/core/src/test/java/org/apache/gravitino/storage/relational/service/TestUserMetaService.java
+++ b/core/src/test/java/org/apache/gravitino/storage/relational/service/TestUserMetaService.java
@@ -46,6 +46,7 @@ import org.apache.gravitino.meta.AuditInfo;
 import org.apache.gravitino.meta.BaseMetalake;
 import org.apache.gravitino.meta.CatalogEntity;
 import org.apache.gravitino.meta.FilesetEntity;
+import org.apache.gravitino.meta.GroupEntity;
 import org.apache.gravitino.meta.RoleEntity;
 import org.apache.gravitino.meta.SchemaEntity;
 import org.apache.gravitino.meta.TableEntity;
@@ -56,6 +57,7 @@ import org.apache.gravitino.storage.relational.TestJDBCBackend;
 import org.apache.gravitino.storage.relational.mapper.RoleMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.UserMetaMapper;
 import org.apache.gravitino.storage.relational.po.RolePO;
+import org.apache.gravitino.storage.relational.po.auth.AuthSubjectVersion;
 import org.apache.gravitino.storage.relational.session.SqlSessionFactoryHelper;
 import org.apache.gravitino.storage.relational.utils.SessionUtils;
 import org.apache.gravitino.utils.NamespaceUtil;
@@ -1160,6 +1162,102 @@ class TestUserMetaService extends TestJDBCBackend {
     deletedCount =
         userMetaService.deleteUserMetasByLegacyTimeline(Instant.now().toEpochMilli() + 1000, 3);
     Assertions.assertEquals(0, deletedCount); // no more to delete
+  }
+
+  @TestTemplate
+  void batchGetUserAndGroupUpdatedAt() throws IOException {
+    AuditInfo auditInfo =
+        AuditInfo.builder().withCreator("creator").withCreateTime(Instant.now()).build();
+    BaseMetalake metalake =
+        createBaseMakeLake(RandomIdGenerator.INSTANCE.nextId(), metalakeName, auditInfo);
+    backend.insert(metalake, false);
+
+    UserMetaService userMetaService = UserMetaService.getInstance();
+    GroupMetaService groupMetaService = GroupMetaService.getInstance();
+
+    UserEntity user =
+        createUserEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            AuthorizationUtils.ofUserNamespace(metalakeName),
+            "batchUser",
+            auditInfo);
+    userMetaService.insertUser(user, false);
+
+    GroupEntity groupA =
+        createGroupEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            AuthorizationUtils.ofGroupNamespace(metalakeName),
+            "batchGroupA",
+            auditInfo,
+            Collections.emptyList(),
+            Collections.emptyList());
+    GroupEntity groupB =
+        createGroupEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            AuthorizationUtils.ofGroupNamespace(metalakeName),
+            "batchGroupB",
+            auditInfo,
+            Collections.emptyList(),
+            Collections.emptyList());
+    groupMetaService.insertGroup(groupA, false);
+    groupMetaService.insertGroup(groupB, false);
+
+    // Case 1: user + multiple groups → UNION returns one row per subject.
+    List<AuthSubjectVersion> rows =
+        SessionUtils.getWithoutCommit(
+            UserMetaMapper.class,
+            m ->
+                m.batchGetUserAndGroupUpdatedAt(
+                    metalakeName, "batchUser", Lists.newArrayList("batchGroupA", "batchGroupB")));
+    assertEquals(3, rows.size());
+    AuthSubjectVersion userRow =
+        rows.stream().filter(r -> "USER".equals(r.getSubjectType())).findFirst().orElseThrow();
+    assertEquals(user.id(), userRow.getId());
+    assertEquals("batchUser", userRow.getName());
+    // updated_at starts at 0 on insert and is bumped by touchUserUpdatedAt; the cache uses it
+    // as a version sentinel, not a wall-clock timestamp, so any value is acceptable here.
+    assertTrue(userRow.getUpdatedAt() >= 0);
+    List<AuthSubjectVersion> groupRows =
+        rows.stream()
+            .filter(r -> "GROUP".equals(r.getSubjectType()))
+            .sorted(Comparator.comparing(AuthSubjectVersion::getName))
+            .collect(java.util.stream.Collectors.toList());
+    assertEquals(2, groupRows.size());
+    assertEquals("batchGroupA", groupRows.get(0).getName());
+    assertEquals(groupA.id(), groupRows.get(0).getId());
+    assertEquals("batchGroupB", groupRows.get(1).getName());
+    assertEquals(groupB.id(), groupRows.get(1).getId());
+
+    // Case 2: empty group list → user-only branch (no UNION, no foreach).
+    List<AuthSubjectVersion> userOnly =
+        SessionUtils.getWithoutCommit(
+            UserMetaMapper.class,
+            m ->
+                m.batchGetUserAndGroupUpdatedAt(
+                    metalakeName, "batchUser", Collections.emptyList()));
+    assertEquals(1, userOnly.size());
+    assertEquals("USER", userOnly.get(0).getSubjectType());
+    assertEquals(user.id(), userOnly.get(0).getId());
+
+    // Case 3: missing user + missing group → row for whichever does exist; empty rows for others.
+    List<AuthSubjectVersion> missing =
+        SessionUtils.getWithoutCommit(
+            UserMetaMapper.class,
+            m ->
+                m.batchGetUserAndGroupUpdatedAt(
+                    metalakeName, "noSuchUser", Lists.newArrayList("noSuchGroup", "batchGroupA")));
+    assertEquals(1, missing.size(), "Only the existing group should be returned");
+    assertEquals("GROUP", missing.get(0).getSubjectType());
+    assertEquals("batchGroupA", missing.get(0).getName());
+
+    // Case 4: both user and groups missing → empty result.
+    List<AuthSubjectVersion> none =
+        SessionUtils.getWithoutCommit(
+            UserMetaMapper.class,
+            m ->
+                m.batchGetUserAndGroupUpdatedAt(
+                    metalakeName, "noSuchUser", Lists.newArrayList("noSuchGroup")));
+    assertTrue(none.isEmpty());
   }
 
   private Integer countUsers(Long metalakeId) {

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
@@ -25,9 +25,11 @@ import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -60,6 +62,7 @@ import org.apache.gravitino.storage.relational.mapper.GroupMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.RoleMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.UserMetaMapper;
 import org.apache.gravitino.storage.relational.po.RolePO;
+import org.apache.gravitino.storage.relational.po.auth.AuthSubjectVersion;
 import org.apache.gravitino.storage.relational.po.auth.GroupUpdatedAt;
 import org.apache.gravitino.storage.relational.po.auth.OwnerInfo;
 import org.apache.gravitino.storage.relational.po.auth.RoleUpdatedAt;
@@ -112,6 +115,18 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
 
   /** Key separator for hierarchical cache keys. */
   static final String KEY_SEP = "::";
+
+  /**
+   * {@code subjectType} literal column value returned by {@link
+   * UserMetaMapper#batchGetUserAndGroupUpdatedAt} for user-meta rows.
+   */
+  private static final String SUBJECT_TYPE_USER = "USER";
+
+  /**
+   * {@code subjectType} literal column value returned by {@link
+   * UserMetaMapper#batchGetUserAndGroupUpdatedAt} for group-meta rows.
+   */
+  private static final String SUBJECT_TYPE_GROUP = "GROUP";
 
   /** Jcasbin enforcer is used for metadata authorization. */
   private Enforcer allowEnforcer;
@@ -552,9 +567,12 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
       long userId;
       UserUpdatedAt userInfo;
       try {
-        // Step 1a: lightweight query — get userId + user.updated_at (version sentinel).
-        //          Per-request dedup: only the first authorize() call for this user hits DB.
-        Optional<UserUpdatedAt> userInfoOpt = loadUserInfo(metalake, username, requestContext);
+        // Step 1a: lightweight UNION query — get userId + user.updated_at AND every group's
+        //          version in one round trip. Subsequent loadUserInfo / loadGroupInfo calls in
+        //          this request hit the per-request cache (0 DB queries).
+        Optional<UserUpdatedAt> userInfoOpt =
+            prefetchUserAndGroupInfo(
+                metalake, username, currentPrincipalGroupNames(), requestContext);
         if (!userInfoOpt.isPresent()) {
           LOG.debug("User {} not found in metalake {}", username, metalake);
           return false;
@@ -605,6 +623,57 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
             Optional.ofNullable(
                 SessionUtils.getWithoutCommit(
                     UserMetaMapper.class, m -> m.getUserUpdatedAt(metalake, username))));
+  }
+
+  /**
+   * Batched version probe that collapses {@link #loadUserInfo} and a per-group {@link
+   * #loadGroupInfo} fan-out into a single UNION query. After this returns, both the per-request
+   * {@code userInfoCache} and {@code groupInfoCache} on {@code requestContext} are primed: every
+   * requested group key is present (mapped to either a {@link GroupUpdatedAt} when the row exists
+   * or {@link Optional#empty()} when the IdP-pushed name is stale).
+   *
+   * <p>Saves {@code N} round trips on the hot path: where the legacy flow paid {@code 1 user_meta +
+   * N group_meta} probes, this pays {@code 1} UNION. {@code N=0} (principal has no groups) degrades
+   * to a plain user-only SELECT via the SQL provider.
+   *
+   * <p>{@code computeXxxIfAbsent} is used to populate the caches so that an entry already cached
+   * from a prior call in the same request is not overwritten — matching {@link #loadUserInfo}'s and
+   * {@link #loadGroupInfo}'s "first wins" dedup semantics.
+   */
+  private Optional<UserUpdatedAt> prefetchUserAndGroupInfo(
+      String metalake,
+      String username,
+      List<String> groupNames,
+      AuthorizationRequestContext requestContext) {
+
+    List<AuthSubjectVersion> rows =
+        SessionUtils.getWithoutCommit(
+            UserMetaMapper.class,
+            m -> m.batchGetUserAndGroupUpdatedAt(metalake, username, groupNames));
+
+    UserUpdatedAt foundUser = null;
+    Map<String, GroupUpdatedAt> foundGroups = new HashMap<>();
+    for (AuthSubjectVersion row : rows) {
+      if (SUBJECT_TYPE_USER.equals(row.getSubjectType())) {
+        foundUser = new UserUpdatedAt(row.getId(), row.getUpdatedAt());
+      } else if (SUBJECT_TYPE_GROUP.equals(row.getSubjectType())) {
+        foundGroups.put(row.getName(), new GroupUpdatedAt(row.getId(), row.getUpdatedAt()));
+      }
+    }
+
+    String userKey = metalake + KEY_SEP + username;
+    final Optional<UserUpdatedAt> userValue = Optional.ofNullable(foundUser);
+    Optional<UserUpdatedAt> userOpt =
+        requestContext.computeUserInfoIfAbsent(userKey, k -> userValue);
+
+    // Negative-cache absent groups too so loadGroupRoles can short-circuit without re-querying.
+    for (String groupName : groupNames) {
+      String groupKey = metalake + KEY_SEP + groupName;
+      final Optional<GroupUpdatedAt> groupValue = Optional.ofNullable(foundGroups.get(groupName));
+      requestContext.computeGroupInfoIfAbsent(groupKey, k -> groupValue);
+    }
+
+    return userOpt;
   }
 
   /**

--- a/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
+++ b/server-common/src/main/java/org/apache/gravitino/server/authorization/jcasbin/JcasbinAuthorizer.java
@@ -44,7 +44,6 @@ import org.apache.gravitino.GravitinoEnv;
 import org.apache.gravitino.MetadataObject;
 import org.apache.gravitino.MetadataObjects;
 import org.apache.gravitino.NameIdentifier;
-import org.apache.gravitino.SupportsRelationOperations;
 import org.apache.gravitino.UserGroup;
 import org.apache.gravitino.UserPrincipal;
 import org.apache.gravitino.auth.AuthConstants;
@@ -360,24 +359,33 @@ public class JcasbinAuthorizer implements GravitinoAuthorizer {
         Long roleId =
             MetadataIdConverter.getID(
                 NameIdentifierUtil.toMetadataObject(nameIdentifier, type), metalake);
-        EntityStore entityStore = GravitinoEnv.getInstance().entityStore();
-        NameIdentifier userNameIdentifier =
-            NameIdentifierUtil.ofUser(metalake, PrincipalUtils.getCurrentUserName());
-        List<RoleEntity> entities =
-            entityStore
-                .relationOperations()
-                .listEntitiesByRelation(
-                    SupportsRelationOperations.Type.ROLE_USER_REL,
-                    userNameIdentifier,
-                    Entity.EntityType.USER);
-        // Check direct user-role assignment
-        if (entities.stream().anyMatch(roleEntity -> Objects.equals(roleEntity.id(), roleId))) {
+
+        // Route through the same version-validated caches that authorize() / isOwner() use, so
+        // the role list comes from userRoleCache / groupRoleCache instead of an extra direct
+        // listEntitiesByRelation call against the EntityStore. The role-list DB queries
+        // (listRolesByUserId / listRolesByGroupId) are then deduplicated across repeated
+        // isSelf(ROLE) calls — and shared with authorize() — by the process-wide Caffeine
+        // caches. The fresh per-call AuthorizationRequestContext only scopes the version
+        // probes (getUserUpdatedAt / getGroupUpdatedAt), which are lightweight single-row
+        // SELECTs and are not the queries the issue calls out as redundant.
+        AuthorizationRequestContext ctx = new AuthorizationRequestContext();
+        Optional<UserUpdatedAt> userInfoOpt = loadUserInfo(metalake, currentUserName, ctx);
+        if (!userInfoOpt.isPresent()) {
+          return false;
+        }
+        UserUpdatedAt userInfo = userInfoOpt.get();
+        long userId = userInfo.getUserId();
+
+        // Direct user-role assignments via the version-validated cache.
+        List<Long> directRoleIds = loadUserRoles(metalake, currentUserName, userId, userInfo);
+        if (directRoleIds.contains(roleId)) {
           return true;
         }
-        // Check group-role assignments.
-        for (GroupEntity groupEntity : resolveCurrentUserGroups(metalake, entityStore)) {
-          List<Long> groupRoleIds = groupEntity.roleIds();
-          if (groupRoleIds != null && groupRoleIds.contains(roleId)) {
+
+        // Group-inherited assignments via the same cache path used by loadRolePrivilege.
+        for (String groupname : currentPrincipalGroupNames()) {
+          List<Long> groupRoleIds = loadGroupRoles(metalake, groupname, userId, ctx);
+          if (groupRoleIds.contains(roleId)) {
             return true;
           }
         }

--- a/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinAuthorizer.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinAuthorizer.java
@@ -24,7 +24,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -76,6 +78,7 @@ import org.apache.gravitino.storage.relational.mapper.RoleMetaMapper;
 import org.apache.gravitino.storage.relational.mapper.UserMetaMapper;
 import org.apache.gravitino.storage.relational.po.RolePO;
 import org.apache.gravitino.storage.relational.po.SecurableObjectPO;
+import org.apache.gravitino.storage.relational.po.auth.AuthSubjectVersion;
 import org.apache.gravitino.storage.relational.po.auth.GroupUpdatedAt;
 import org.apache.gravitino.storage.relational.po.auth.OwnerInfo;
 import org.apache.gravitino.storage.relational.po.auth.RoleUpdatedAt;
@@ -203,6 +206,31 @@ public class TestJcasbinAuthorizer {
     // Default mock: getUserInfo returns a valid user
     when(userMetaMapper.getUserUpdatedAt(eq(METALAKE), eq(USERNAME)))
         .thenReturn(new UserUpdatedAt(USER_ID, 1000L));
+
+    // The hot path uses batchGetUserAndGroupUpdatedAt to fetch user + all group versions in one
+    // UNION query; synthesize its result from the per-subject getUserUpdatedAt /
+    // getGroupUpdatedAt stubs so tests can keep stubbing those at the per-subject granularity.
+    when(userMetaMapper.batchGetUserAndGroupUpdatedAt(anyString(), anyString(), anyList()))
+        .thenAnswer(
+            invocation -> {
+              String mlk = invocation.getArgument(0);
+              String uname = invocation.getArgument(1);
+              List<String> gNames = invocation.getArgument(2);
+              List<AuthSubjectVersion> rows = new ArrayList<>();
+              UserUpdatedAt u = userMetaMapper.getUserUpdatedAt(mlk, uname);
+              if (u != null) {
+                rows.add(new AuthSubjectVersion("USER", u.getUserId(), uname, u.getUpdatedAt()));
+              }
+              if (gNames != null) {
+                for (String gn : gNames) {
+                  GroupUpdatedAt g = groupMetaMapper.getGroupUpdatedAt(mlk, gn);
+                  if (g != null) {
+                    rows.add(new AuthSubjectVersion("GROUP", g.getGroupId(), gn, g.getUpdatedAt()));
+                  }
+                }
+              }
+              return rows;
+            });
 
     // Default: no roles assigned initially
     when(roleMetaMapper.listRolesByUserId(eq(USER_ID))).thenReturn(ImmutableList.of());

--- a/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinAuthorizer.java
+++ b/server-common/src/test/java/org/apache/gravitino/server/authorization/jcasbin/TestJcasbinAuthorizer.java
@@ -97,6 +97,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 /** Test of {@link JcasbinAuthorizer} */
 public class TestJcasbinAuthorizer {
@@ -614,6 +615,54 @@ public class TestJcasbinAuthorizer {
     // A principal with no groups should fail
     setCurrentPrincipalWithGroup(null);
     assertFalse(jcasbinAuthorizer.isSelf(Entity.EntityType.ROLE, roleIdent));
+
+    restoreDefaultPrincipal();
+  }
+
+  @Test
+  public void testIsSelfRoleReusesCacheAcrossCalls() throws Exception {
+    // Acceptance criterion for #11088: repeated isSelf(ROLE) calls in the same logical request
+    // must not re-issue the role-list DB queries (listRolesByUserId / listRolesByGroupId).
+    // The version-validated userRoleCache / groupRoleCache are process-wide, so the second call
+    // hits cache even though each isSelf creates a fresh AuthorizationRequestContext.
+    //
+    // Use CATALOG_ID so the role id matches the catch-all MetadataIdConverter.getID mock.
+    Long directRoleId = CATALOG_ID;
+    String directRoleName = "selfDedupRole";
+    NameIdentifier roleIdent = NameIdentifierUtil.ofRole(METALAKE, directRoleName);
+
+    // Direct user-role assignment via the version-validated cache path.
+    mockUserRoles(directRoleId, directRoleName);
+
+    // Use a fresh authorizer + principal to ensure the userRoleCache starts cold.
+    setCurrentPrincipalWithGroup(null);
+    Mockito.clearInvocations(roleMetaMapper);
+
+    // 1st call: miss → listRolesByUserId; 2nd call: cache hit → no extra listRolesByUserId.
+    assertTrue(jcasbinAuthorizer.isSelf(Entity.EntityType.ROLE, roleIdent));
+    assertTrue(jcasbinAuthorizer.isSelf(Entity.EntityType.ROLE, roleIdent));
+
+    Mockito.verify(roleMetaMapper, Mockito.times(1)).listRolesByUserId(eq(USER_ID));
+
+    restoreDefaultPrincipal();
+  }
+
+  @Test
+  public void testIsSelfRoleDoesNotCallListEntitiesByRelation() throws Exception {
+    // #11088: isSelf(ROLE) must not bypass the cache by going straight to
+    // entityStore.relationOperations().listEntitiesByRelation(ROLE_USER_REL, ...).
+    Long directRoleId = CATALOG_ID;
+    String directRoleName = "noBypassRole";
+    NameIdentifier roleIdent = NameIdentifierUtil.ofRole(METALAKE, directRoleName);
+
+    mockUserRoles(directRoleId, directRoleName);
+    setCurrentPrincipalWithGroup(null);
+    Mockito.clearInvocations(supportsRelationOperations);
+
+    assertTrue(jcasbinAuthorizer.isSelf(Entity.EntityType.ROLE, roleIdent));
+
+    Mockito.verify(supportsRelationOperations, Mockito.never())
+        .listEntitiesByRelation(any(), any(), any());
 
     restoreDefaultPrincipal();
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Two related changes on top of `feat/jcasbin-cache-refactor`:

**Commit 1 — batch user + group version probes (`039bdd7d3`)**
On the authorize() hot path with all caches warm, the per-request version
probes for the current user + each of the user's groups ran as `1 + N`
separate `getUserUpdatedAt` / `getGroupUpdatedAt` SELECTs. Collapse them
into a single `UNION ALL` query:

- New `AuthSubjectVersion` POJO carrying one row of the UNION result.
- New `UserMetaMapper.batchGetUserAndGroupUpdatedAt` mapper method, one
  base SQL provider, no per-backend override; empty `groupNames`
  degrades to a user-only SELECT so we avoid an empty IN clause across
  H2 / MySQL / PostgreSQL.
- New `JcasbinAuthorizer.prefetchUserAndGroupInfo` runs the batch once
  at the top of `loadPrivilegeAndAuthorize` and primes both the
  per-request `userInfoCache` and `groupInfoCache` via
  `computeXxxIfAbsent`. Subsequent `loadUserInfo` / `loadGroupInfo`
  calls in the same request hit the per-request cache (0 DB queries).

For N groups, hot path drops from `N+2` queries to `2`.

**Commit 2 — route `isSelf(ROLE)` through the cache (`232053523`, fixes #11088)**
`isSelf(ROLE)` was the last call site bypassing the version-validated
`userRoleCache` / `groupRoleCache` and going straight to
`entityStore.relationOperations().listEntitiesByRelation(ROLE_USER_REL)`
plus a batchGet over the user's groups. Switch the ROLE branch to:
1. `loadUserInfo` for `user_id` + `updated_at`,
2. `loadUserRoles` for the direct role list (cached, version-validated),
3. `loadGroupRoles` per group from the principal (same cache path).

Repeated `isSelf(ROLE)` calls in the same request — and `isSelf` following
`authorize()` — now resolve the role list from the process-wide cache
instead of re-querying `user_role_rel` / `group_meta`.

### Why are the changes needed?

`isSelf(ROLE)` is invoked from `AuthorizationExpressionEvaluator` for
every authorization expression that references role identity, so the
redundant role-list fetch landed on every such request. Issue #11088
called out the inconsistency with `authorize()` / `isOwner()`, which
were already using the cache. The batch-probe optimization in commit 1
is the prerequisite that makes the per-request user + group fan-out
cheap enough to also serve repeated `isSelf` calls without measurable
overhead.

`isSelf` does not take an `AuthorizationRequestContext`, so the new
implementation allocates a fresh per-call context. This scopes only the
lightweight version probes (`getUserUpdatedAt` / `getGroupUpdatedAt`);
the role-list queries the issue calls out are still deduplicated across
all calls by the shared cache, which is what the acceptance criterion
asks for. Threading the context through would ripple into the
`GravitinoAuthorizer` interface, `PassThroughAuthorizer`, and the
`AuthorizationExpressionConverter` template; left as a follow-up.

Fix: #11088

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `./gradlew :server-common:test --tests 'org.apache.gravitino.server.authorization.jcasbin.*'` — 39/39 pass (9 lookup + 23 authorizer + 2 cacheHelpers + 5 poller).
- New `testIsSelfRoleReusesCacheAcrossCalls` asserts that two `isSelf(ROLE)` calls in a row issue exactly one `listRolesByUserId` (the #11088 AC).
- New `testIsSelfRoleDoesNotCallListEntitiesByRelation` asserts the old EntityStore bypass is gone.
- New `TestUserMetaService.batchGetUserAndGroupUpdatedAt` IT covers user-only, user+groups, partial-missing, and all-missing scenarios on H2 (10/10). The MySQL/PG branches of the parameterized test could not be exercised in my local environment due to testcontainers setup issues; the SQL mirrors the existing `batchGetRoleUpdatedAt` pattern that already works across all three backends in CI.

### Note for reviewer

This PR is stacked on `feat/jcasbin-cache-refactor` (PR #10996); please review #10996 first, or rebase onto main after #10996 lands.